### PR TITLE
Add velocity vector overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ End goal is to develop a particle based simulator of electrochemical charging an
 - **Configurable Parameters**: Easily adjust simulation size, physics constants, and visualization options.
 - **Extensible**: Well-structured for adding new physics, force laws, or visualization features.
 - **Visual Debugging**: See selected particles highlighted with a halo and view live charge values.
+- **Velocity Vector Overlay**: Toggle drawing of velocity vectors to visualize particle motion.
 - Draws heavily from original source: https://github.com/DeadlockCode/barnes-hut.git
 
 ---

--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -56,11 +56,25 @@ impl super::Renderer {
                     if body.species == Species::LithiumMetal {
                         for electron in &body.electrons {
                             let electron_pos = body.pos + electron.rel_pos;
-                            ctx.draw_circle(electron_pos, body.radius * 0.3, [0, 128, 255, 255]); // blue
+                            ctx.draw_circle(
+                                electron_pos,
+                                body.radius * 0.3,
+                                [0, 128, 255, 255],
+                            ); // blue
                         }
                     }
-				}   
-			}
+                                }
+                        }
+
+            // --- Velocity Vector Overlay ---
+            if self.sim_config.show_velocity_vectors {
+                const SCALE: f32 = 5.0;
+                let color = [0, 255, 0, 255]; // green
+                for body in &self.bodies {
+                    let end = body.pos + body.vel * SCALE;
+                    ctx.draw_line(body.pos, end, color);
+                }
+            }
 
 
             if let Some(body) = &self.confirmed_bodies {


### PR DESCRIPTION
## Summary
- add ability to draw velocity vectors in `draw` when enabled in config
- document the velocity vector overlay in README

## Testing
- `cargo check` *(fails: could not fetch dependency)*