### PR TITLE
Implement electron density heatmap overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ End goal is to develop a particle based simulator of electrochemical charging an
 - **Configurable Parameters**: Easily adjust simulation size, physics constants, and visualization options.
 - **Extensible**: Well-structured for adding new physics, force laws, or visualization features.
 - **Visual Debugging**: See selected particles highlighted with a halo and view live charge values.
+- **Electron Density Heatmap**: Toggle a translucent overlay to visualize where electrons concentrate.
 - Draws heavily from original source: https://github.com/DeadlockCode/barnes-hut.git
 
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@
 pub const ELECTRON_SPRING_K: f32 = 0.05;                // Spring constant for electron drift
 pub const ELECTRON_DRIFT_RADIUS_FACTOR: f32 = 1.2;      // Max drift radius as a factor of body radius
 pub const ELECTRON_MAX_SPEED_FACTOR: f32 = 1.2;         // Max electron speed as a factor of body radius per dt
+pub const ELECTRON_DENSITY_RADIUS: f32 = 0.5;           // Radius for visualizing electron density
 pub const _HOP_CHARGE_THRESHOLD: f32 = 0.2;                     // Charge threshold for hopping
 pub const HOP_RADIUS_FACTOR: f32 = 2.1;                      // Hopping radius as a factor of body radius
 pub const HOP_RATE_K0: f32 = 1.0;            /// Base hop‐rate constant (per unit time) at zero overpotential

--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -26,8 +26,8 @@ impl super::Renderer {
         ctx.set_view_scale(self.scale);
 
         if !self.bodies.is_empty() {
-			if self.show_bodies {
-				for body in &self.bodies {
+                        if self.show_bodies {
+                                for body in &self.bodies {
 					// Map charge to RGB color: red for positive, blue for negative, white for 0
 					/*let charge = body.charge;
 					let max_charge = 1.0; // adjust if needed
@@ -57,8 +57,22 @@ impl super::Renderer {
                         for electron in &body.electrons {
                             let electron_pos = body.pos + electron.rel_pos;
                             ctx.draw_circle(electron_pos, body.radius * 0.3, [0, 128, 255, 255]); // blue
+                                }
+                        }
+
+            // --- ELECTRON DENSITY OVERLAY ---
+            if self.sim_config.show_electron_density {
+                let radius = crate::config::ELECTRON_DENSITY_RADIUS;
+                let color = [0, 0, 255, 64]; // translucent blue
+                for body in &self.bodies {
+                    if body.species == Species::LithiumMetal {
+                        for electron in &body.electrons {
+                            let pos = body.pos + electron.rel_pos;
+                            ctx.draw_circle(pos, radius, color);
                         }
                     }
+                }
+            }
 				}   
 			}
 


### PR DESCRIPTION
## Summary
- add missing electron density constant
- draw density heatmap overlay when enabled in the GUI
- document electron density heatmap feature

## Testing
- `cargo test` *(fails: failed to fetch git dependency)*