### PR TITLE
Switched the order of quadtree building to avoid calling acc or pos e…

### DIFF
--- a/src/body/tests.rs
+++ b/src/body/tests.rs
@@ -103,6 +103,7 @@ mod physics {
         };
         assert_eq!(sim.bodies[0].electrons.len(), 0);
         assert_eq!(sim.bodies[1].electrons.len(), 3);
+        sim.quadtree.build(&mut sim.bodies);
         sim.perform_electron_hopping();
         assert_eq!(sim.bodies[0].electrons.len(), 1);
         assert_eq!(sim.bodies[1].electrons.len(), 2);

--- a/src/quadtree/quadtree.rs
+++ b/src/quadtree/quadtree.rs
@@ -179,9 +179,13 @@ impl Quadtree {
 
     pub fn acc_pos(&self, pos: Vec2, q: f32, bodies: &[Body], k_e: f32) -> Vec2 {
         let mut acc = Vec2::zero();
-
         let mut node = Self::ROOT;
+        let mut _iter_count = 0;
         loop {
+            _iter_count += 1;
+            if node >= self.nodes.len() {
+                break;
+            }
             let n = self.nodes[node].clone();
 
             let d = pos - n.pos;

--- a/src/simulation/tests.rs
+++ b/src/simulation/tests.rs
@@ -229,6 +229,7 @@ mod reactions {
                 },
                 foils: Vec::new(),
             };
+            sim.quadtree.build(&mut sim.bodies);
             sim.perform_electron_hopping();
             sim.bodies[0].update_charge_from_electrons();   
             sim.bodies[1].update_charge_from_electrons();   
@@ -340,6 +341,7 @@ mod reactions {
                 },
                 foils: Vec::new(),
             };
+            sim.quadtree.build(&mut sim.bodies);
             sim.perform_electron_hopping();
             // after hopping, a should lose one electron, b should gain one
             assert_eq!(sim.bodies[0].electrons.len(), 1);


### PR DESCRIPTION
…dits before the tree is built in testing