### PR TITLE
Reuse neighbor buffer

### DIFF
--- a/src/quadtree/quadtree.rs
+++ b/src/quadtree/quadtree.rs
@@ -244,9 +244,10 @@ impl Quadtree {
         });
     }
 
-    /// Find indices of bodies within `cutoff` distance of body at index `i` (excluding `i` itself)
-    pub fn find_neighbors_within(&self, bodies: &[Body], i: usize, cutoff: f32) -> Vec<usize> {
-        let mut neighbors = Vec::new();
+    /// Find indices of bodies within `cutoff` distance of body at index `i` (excluding `i` itself).
+    /// The provided `neighbors` vector is cleared and filled with the result.
+    pub fn find_neighbors_within(&self, bodies: &[Body], i: usize, cutoff: f32, neighbors: &mut Vec<usize>) {
+        neighbors.clear();
         let pos = bodies[i].pos;
         let cutoff_sq = cutoff * cutoff;
 
@@ -281,7 +282,7 @@ impl Quadtree {
                 }
             }
         }
-        neighbors
+        
     }
 
     /// Compute the electric field at an arbitrary point using the quadtree (Barnes-Hut).

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -45,12 +45,12 @@ pub fn apply_lj_forces(sim: &mut Simulation) {
     let sigma = sim.config.lj_force_sigma;
     let epsilon = sim.config.lj_force_epsilon;
     let cutoff = sim.config.lj_force_cutoff * sigma;
+    let mut neighbors = Vec::new();
     for i in 0..sim.bodies.len() {
-        // Only apply LJ to LithiumMetal or FoilMetal
         if !(sim.bodies[i].species == Species::LithiumMetal || sim.bodies[i].species == Species::FoilMetal) {
             continue;
         }
-        let neighbors = sim.quadtree.find_neighbors_within(&sim.bodies, i, cutoff);
+        sim.quadtree.find_neighbors_within(&sim.bodies, i, cutoff, &mut neighbors);
         for &j in &neighbors {
             if j <= i { continue; }
             let (a, b) = {

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -182,6 +182,7 @@ impl Simulation {
         let mut src_indices: Vec<usize> = (0..n).collect();
         let mut rng = rand::rng();
         src_indices.shuffle(&mut rng);
+        let mut neighbor_buf = Vec::new();
         for &src_idx in &src_indices {
             if donated_electron[src_idx] { continue; } // Only allow one hop per donor per step
             let src_body = &self.bodies[src_idx];
@@ -193,9 +194,10 @@ impl Simulation {
             let hop_radius = self.config.hop_radius_factor * src_body.radius;
 
             // Use quadtree for neighbor search!
-            let mut candidate_neighbors = self.quadtree
-                .find_neighbors_within(&self.bodies, src_idx, hop_radius)
-                .into_iter()
+            self.quadtree.find_neighbors_within(&self.bodies, src_idx, hop_radius, &mut neighbor_buf);
+            let mut candidate_neighbors = neighbor_buf
+                .iter()
+                .copied()
                 .filter(|&dst_idx| dst_idx != src_idx && !received_electron[dst_idx])
                 .filter(|&dst_idx| {
                     let dst_body = &self.bodies[dst_idx];
@@ -279,9 +281,10 @@ impl Simulation {
             let hop_radius = self.config.hop_radius_factor * src_body.radius;
 
             // Use quadtree for neighbor search!
-            let mut candidate_neighbors = self.quadtree
-                .find_neighbors_within(&self.bodies, src_idx, hop_radius)
-                .into_iter()
+            self.quadtree.find_neighbors_within(&self.bodies, src_idx, hop_radius, &mut neighbor_buf);
+            let mut candidate_neighbors = neighbor_buf
+                .iter()
+                .copied()
                 .filter(|&dst_idx| dst_idx != src_idx && !received_electron[dst_idx])
                 .filter(|&dst_idx| {
                     let dst_body = &self.bodies[dst_idx];


### PR DESCRIPTION
## Summary
- reuse neighbor vectors instead of allocating each call
- update LJ and electron hopping code to pass buffer

## Testing
- `cargo test` *(fails: `bash: cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68456cb097d8833284e5a219fd4c96dd