### PR TITLE
Add built-in profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ crossbeam = "0.8.4"
 broccoli-rayon = "0.4.0"
 rand = "0.9.1"
 smallvec = "1.10.0"
+
+[features]
+profiling = []

--- a/README.md
+++ b/README.md
@@ -94,10 +94,16 @@ This repository contains a modular, parallelized Barnes-Hut simulation for large
   Use the new GUI button to advance one timestep at a time for detailed debugging.
 - **Adding New Features**:  
   Extend physics or visualization modules easily thanks to the modular code organization.
-- **Testing**:  
+- **Testing**:
   Run the comprehensive test suite with:
   ```sh
   cargo test
+  ```
+- **Profiling**:
+  Enable the built-in profiler with the `profiling` feature to print per-frame
+  timings:
+  ```sh
+  cargo run --features profiling
   ```
 
 ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,6 @@ mod utils;
 mod config;
 mod profiler;
 
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
-
 use crate::body::Species;
 use renderer::Renderer;
 use renderer::state::{SIM_COMMAND_SENDER, SimCommand};
@@ -26,6 +23,12 @@ use std::sync::mpsc::channel;
 use simulation::Simulation;
 use crate::body::Electron;
 use ultraviolet::Vec2;
+
+#[cfg(feature = "profiling")]   
+use once_cell::sync::Lazy;
+
+#[cfg(feature = "profiling")]   
+use parking_lot::Mutex;
 
 #[cfg(feature = "profiling")]
 pub static PROFILER: Lazy<Mutex<profiler::Profiler>> = Lazy::new(|| {
@@ -175,7 +178,7 @@ fn main() {
                         render(&mut simulation);
                         #[cfg(feature = "profiling")]
                         {
-                            PROFILER.lock().print_and_clear();
+                            PROFILER.lock().print_and_clear(Some(&simulation), None);
                         }
                         // Optionally, pause the simulation if desired:
                         PAUSED.store(true, Ordering::Relaxed);
@@ -295,7 +298,7 @@ fn main() {
             render(&mut simulation);
             #[cfg(feature = "profiling")]
             {
-                PROFILER.lock().print_and_clear();
+                PROFILER.lock().print_and_clear_if_running(!PAUSED.load(Ordering::Relaxed), Some(&simulation), None);
             }
         }
     });

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Simple scoped profiler recording cumulative time per section.
+pub struct Profiler {
+    pub timings: HashMap<&'static str, Duration>,
+}
+
+impl Profiler {
+    pub fn new() -> Self {
+        Self { timings: HashMap::new() }
+    }
+
+    pub fn finish(&mut self, guard: &ProfilerGuard) {
+        let elapsed = guard.start.elapsed();
+        *self.timings.entry(guard.name).or_default() += elapsed;
+    }
+
+    pub fn report_sorted(&self) -> Vec<(&'static str, Duration)> {
+        let mut v: Vec<_> = self.timings.iter().map(|(n, d)| (*n, *d)).collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1));
+        v
+    }
+
+    pub fn clear(&mut self) {
+        self.timings.clear();
+    }
+
+    pub fn print_and_clear(&mut self) {
+        for (name, dur) in self.report_sorted() {
+            println!("{:<20} {:?}", name, dur);
+        }
+        self.clear();
+    }
+}
+
+pub struct ProfilerGuard {
+    name: &'static str,
+    start: Instant,
+}
+
+/// Start a profiling section. Returns a guard that will update the global
+/// profiler when dropped.
+pub fn start(name: &'static str) -> ProfilerGuard {
+    ProfilerGuard { name, start: Instant::now() }
+}
+
+#[cfg(feature = "profiling")]
+impl Drop for ProfilerGuard {
+    fn drop(&mut self) {
+        crate::PROFILER.lock().finish(self);
+    }
+}
+
+/// Macro helper to profile a scope only when the `profiling` feature is enabled.
+#[macro_export]
+macro_rules! profile_scope {
+    ($name:expr) => {
+        #[cfg(feature = "profiling")]
+        let _guard = $crate::profiler::start($name);
+    };
+}

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -26,11 +26,76 @@ impl Profiler {
         self.timings.clear();
     }
 
-    pub fn print_and_clear(&mut self) {
-        for (name, dur) in self.report_sorted() {
-            println!("{:<20} {:?}", name, dur);
+    pub fn print_and_clear(&mut self, sim: Option<&crate::simulation::Simulation>, fps: Option<f32>) {
+        use std::collections::HashSet;
+        let sorted = self.report_sorted();
+        if sorted.is_empty() {
+            return;
+        }
+        // Move cursor to top-left (no full clear)
+        print!("\x1B[H");
+        use std::io::{self, Write};
+        io::stdout().flush().ok();
+
+        // List of expected section names (add/remove as needed)
+        let expected_sections = [
+            "simulation_step",
+            "forces_lj",
+            "quadtree_neighbors",
+            "quadtree_build",
+            "forces_attract",
+            "collision",
+            "quadtree_field",
+            "iterate",
+        ];
+        let mut seen = HashSet::new();
+        let mut total: f64 = 0.0;
+        let mut section_map = std::collections::HashMap::new();
+        for (name, dur) in &sorted {
+            section_map.insert(*name, *dur);
+            total += dur.as_secs_f64() * 1000.0;
+        }
+        println!("\nEnd of step profile summary:");
+        println!("{:<20} {:>10}   {:>8}", "Section", "Time", "% of step");
+        for &section in &expected_sections {
+            let ms = section_map.get(section).map(|d| d.as_secs_f64() * 1000.0).unwrap_or(0.0);
+            let percent = if total > 0.0 { 100.0 * ms / total } else { 0.0 };
+            println!("{:<20} {:>8.4}ms   {:>6.2}%", section, ms, percent);
+            seen.insert(section);
+        }
+        // Print any extra sections not in expected list
+        for (name, dur) in &sorted {
+            if !seen.contains(name) {
+                let ms = dur.as_secs_f64() * 1000.0;
+                let percent = if total > 0.0 { 100.0 * ms / total } else { 0.0 };
+                println!("{:<20} {:>8.4}ms   {:>6.2}%", name, ms, percent);
+            }
+        }
+        println!("{:<20} {:>8.4}ms   100.00%", "TOTAL", total);
+
+        // Print simulation stats if provided
+        if let Some(sim) = sim {
+            let total_particles = sim.bodies.len();
+            let num_ions = sim.bodies.iter().filter(|b| matches!(b.species, crate::body::Species::LithiumIon)).count();
+            let num_metals = sim.bodies.iter().filter(|b| matches!(b.species, crate::body::Species::LithiumMetal | crate::body::Species::FoilMetal)).count();
+            let num_electrons: usize = sim.bodies.iter().map(|b| b.electrons.len()).sum();
+            let num_foils = sim.foils.len();
+            println!("\nParticles: {}   Ions: {}   Metals: {}   Electrons: {}   Foils: {}", total_particles, num_ions, num_metals, num_electrons, num_foils);
+        } else {
+            println!("\nParticles: 0   Ions: 0   Metals: 0   Electrons: 0   Foils: 0");
+        }
+        // Print FPS if provided
+        if let Some(fps) = fps {
+            println!("FPS: {:.1}", fps);
         }
         self.clear();
+    }
+
+    pub fn print_and_clear_if_running(&mut self, running: bool, sim: Option<&crate::simulation::Simulation>, fps: Option<f32>) {
+        if running {
+            self.print_and_clear(sim, fps);
+        }
+        // If not running, do not print or clear; keep timings for inspection
     }
 }
 

--- a/src/quadtree/quadtree.rs
+++ b/src/quadtree/quadtree.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::ops::Range;
 use rayon::prelude::*;
 use crate::partition::Partition;
+use crate::profile_scope;
 
 pub struct Quadtree {
     pub t_sq: f32,

--- a/src/quadtree/quadtree.rs
+++ b/src/quadtree/quadtree.rs
@@ -99,6 +99,7 @@ impl Quadtree {
     }
 
     pub fn build(&mut self, bodies: &mut [Body]) {
+        profile_scope!("quadtree_build");
         if bodies.is_empty() {
             self.clear();
             return;
@@ -235,6 +236,7 @@ impl Quadtree {
     }
 
     pub fn field(&self, bodies: &mut Vec<Body>, k_e: f32) {
+        profile_scope!("quadtree_field");
         let bodies_ptr = std::ptr::addr_of_mut!(*bodies) as usize;
 
         bodies.par_iter_mut().for_each(|body| {
@@ -246,6 +248,7 @@ impl Quadtree {
 
     /// Find indices of bodies within `cutoff` distance of body at index `i` (excluding `i` itself)
     pub fn find_neighbors_within(&self, bodies: &[Body], i: usize, cutoff: f32) -> Vec<usize> {
+        profile_scope!("quadtree_neighbors");
         let mut neighbors = Vec::new();
         let pos = bodies[i].pos;
         let cutoff_sq = cutoff * cutoff;

--- a/src/simulation/collision.rs
+++ b/src/simulation/collision.rs
@@ -7,6 +7,7 @@ use broccoli::aabb::Rect;
 use broccoli_rayon::{build::RayonBuildPar, prelude::RayonQueryPar};
 use ultraviolet::Vec2;
 use crate::simulation::Simulation;
+use crate::profile_scope;
 
 pub fn collide(sim: &mut Simulation) {
     profile_scope!("collision");

--- a/src/simulation/collision.rs
+++ b/src/simulation/collision.rs
@@ -9,6 +9,7 @@ use ultraviolet::Vec2;
 use crate::simulation::Simulation;
 
 pub fn collide(sim: &mut Simulation) {
+    profile_scope!("collision");
     let mut rects = sim
         .bodies
         .iter()

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -6,6 +6,7 @@
 use crate::body::Species;
 use crate::config;
 use crate::simulation::Simulation;
+use crate::profile_scope;
 
 /// Coulomb's constant (scaled for simulation units).
 pub const K_E: f32 = 8.988e3 * 0.5;

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -16,6 +16,7 @@ pub const K_E: f32 = 8.988e3 * 0.5;
 /// - Computes the electric field at each body due to all others.
 /// - Adds background field and updates acceleration (F = qE).
 pub fn attract(sim: &mut Simulation) {
+    profile_scope!("forces_attract");
     sim.quadtree.build(&mut sim.bodies);
     sim.quadtree.field(&mut sim.bodies, K_E);
     for body in &mut sim.bodies {
@@ -34,6 +35,7 @@ pub fn attract(sim: &mut Simulation) {
 /// - Uses the quadtree to find neighbors efficiently.
 /// - Forces are clamped to avoid instability.
 pub fn apply_lj_forces(sim: &mut Simulation) {
+    profile_scope!("forces_lj");
     // Debug: Print all lithium metals in the simulation
     let mut metal_indices = vec![];
     for (i, b) in sim.bodies.iter().enumerate() {

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -60,6 +60,7 @@ impl Simulation {
     }
 
     pub fn step(&mut self) {
+        profile_scope!("simulation_step");
         // Sync config from global LJ_CONFIG (updated by GUI)
         self.config = crate::config::LJ_CONFIG.lock().clone();
 
@@ -151,6 +152,7 @@ impl Simulation {
     }
 
     pub fn iterate(&mut self) {
+        profile_scope!("iterate");
         // Damping factor scales with timestep and is user-configurable
         let dt = self.dt;
         let damping = self.config.damping_base.powf(dt / 0.01);

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -9,6 +9,7 @@ use super::collision;
 use crate::config;
 use crate::simulation::utils::can_transfer_electron;
 use rand::prelude::*; // Import all prelude traits for rand 0.9+
+use crate::profile_scope;
 
 /// The main simulation state and logic for the particle system.
 pub struct Simulation {


### PR DESCRIPTION
## Summary
- add optional profiling feature and implementation
- expose global `PROFILER` and scope macro
- instrument heavy routines with `profile_scope!`
- log timings each frame when profiling enabled
- document how to build with profiling

## Testing
- `cargo check` *(fails: could not fetch git dependencies)*
- `cargo test` *(fails: could not fetch git dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68457f45a34883329a85952e89693567