### PR TITLE
Remove leftover debug variable

### DIFF
--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -37,14 +37,6 @@ pub fn attract(sim: &mut Simulation) {
 /// - Forces are clamped to avoid instability.
 pub fn apply_lj_forces(sim: &mut Simulation) {
     profile_scope!("forces_lj");
-    // Debug: Print all lithium metals in the simulation
-    let mut metal_indices = vec![];
-    for (i, b) in sim.bodies.iter().enumerate() {
-        if b.species == Species::LithiumMetal {
-            metal_indices.push(i);
-        }
-    }
-
     let sigma = sim.config.lj_force_sigma;
     let epsilon = sim.config.lj_force_epsilon;
     let cutoff = sim.config.lj_force_cutoff * sigma;


### PR DESCRIPTION
## Summary
- remove unused `metal_indices` debug code from `apply_lj_forces`

## Testing
- `cargo test` *(fails: failed to fetch `quarkstrom` dependency)*

------
https://chatgpt.com/codex/tasks/task_b_684cf06df370833299d37066c2aa4b7d