### PR TITLE
Avoid body cloning when updating electrons

### DIFF
--- a/src/body/electron.rs
+++ b/src/body/electron.rs
@@ -11,16 +11,23 @@ pub struct Electron {
 }
 
 use super::types::Body;
+use crate::quadtree::Quadtree;
 
 impl Body {
-    pub fn update_electrons<F>(&mut self, field_at: F, dt: f32)
-    where
-        F: Fn(Vec2) -> Vec2,
-    {
+    pub fn update_electrons(
+        &mut self,
+        bodies: &[Body],
+        self_idx: usize,
+        quadtree: &Quadtree,
+        background_field: Vec2,
+        dt: f32,
+    ) {
         let k = config::ELECTRON_SPRING_K;
         for e in &mut self.electrons {
             let electron_pos = self.pos + e.rel_pos;
-            let local_field = field_at(electron_pos);
+            let local_field =
+                quadtree.field_at_point(bodies, electron_pos, crate::simulation::forces::K_E)
+                    + background_field;
             let acc = -local_field * k;
             e.vel += acc * dt;
             let speed = e.vel.mag();

--- a/src/body/tests.rs
+++ b/src/body/tests.rs
@@ -120,9 +120,12 @@ mod tests {
             );
             b.electrons=smallvec![Electron {rel_pos:Vec2::zero(),vel:Vec2::zero()}];
             let field = Vec2::new(1.0, 0.0);
-            b.update_electrons(|_pos| field, 0.1);
-            assert!(b.electrons[0].rel_pos.x < 0.0,
-                "Expected electron to drift left (x < 0), but rel_pos.x = {}", b.electrons[0].rel_pos.x);
+            let mut bodies = vec![b.clone()];
+            let qt = Quadtree::new(0.5, 0.01, 1, 1);
+            qt.build(&mut bodies);
+            bodies[0].update_electrons(&bodies, 0, &qt, field, 0.1);
+            assert!(bodies[0].electrons[0].rel_pos.x < 0.0,
+                "Expected electron to drift left (x < 0), but rel_pos.x = {}", bodies[0].electrons[0].rel_pos.x);
         }
 
         // Update all test calls to use the new exclusion-aware hopping function


### PR DESCRIPTION
## Summary
- update `Body::update_electrons` to take bodies slice and index
- refactor `Simulation::step` to pass bodies slice using raw pointer and index instead of cloning
- adapt unit tests

## Testing
- `cargo test --quiet` *(fails: failed to get `quarkstrom` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_b_684cf05825008332a1939bbd1de9dd3b