### PR TITLE
Clean up unused redox and quadtree code

### DIFF
--- a/src/quadtree/mod.rs
+++ b/src/quadtree/mod.rs
@@ -1,11 +1,7 @@
 pub mod node;
 pub mod quad;
-pub mod traits;
-
-
 pub use node::Node;
 //pub use quad::Quad;
-//pub use traits::*;
 
 mod quadtree;
 pub use quadtree::Quadtree;

--- a/src/quadtree/traits.rs
+++ b/src/quadtree/traits.rs
@@ -1,4 +1,0 @@
-/*pub trait Spatial {
-    fn position(&self) -> ultraviolet::Vec2;
-    // Add more trait methods as needed
-}*/

--- a/src/simulation/tests.rs
+++ b/src/simulation/tests.rs
@@ -1,5 +1,4 @@
-// simulation/redox_tests.rs
-// Contains redox-related tests for the Simulation and Body
+// Redox-related tests for the Simulation and Body
 
 use super::simulation::Simulation;
 use crate::body::{Body, Electron, Species};


### PR DESCRIPTION
## Summary
- remove empty `redox_tests` module
- delete unused `quadtree/traits` module
- update quadtree module exports
- fix comment in `simulation/tests`

## Testing
- `cargo check` *(fails: could not connect to crates.io)*
- `cargo test` *(fails: could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_b_684cf04feb508332b15df93a07589b54