### PR TITLE
Add LJ/Coulomb force ratio debug overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains a modular, parallelized Barnes-Hut simulation for large
 - **Live Force Tracking & Debugging**:  
   - Separate accumulation and visualization of Coulomb and Lennard-Jones (LJ) forces.
   - Debug prints (configurable via the GUI) display per-body force vectors, acceleration, and velocity.
+  - Optional overlay colors each particle by the LJ/Coulomb force ratio.
 - **Interactive GUI**:  
   - Real-time visualization and controls via [quarkstrom](https://github.com/DeadlockCode/quarkstrom).
   - **Manual Step Button**: Step the simulation forward by one timestep per click for precise debugging.
@@ -70,8 +71,9 @@ This repository contains a modular, parallelized Barnes-Hut simulation for large
 - **Scenario Setup**:  
   - **Delete All Particles**: Clears the simulation space immediately.
   - **Add Circle / Rectangle / Foil**: Spawn configured groups of particles quickly—ideal for rapid prototyping and testing.
-- **Force Visualization Overlays**:  
+- **Force Visualization Overlays**:
   Toggle overlays for velocity vectors, charge density, and force ratio display.
+  When enabled, a color-coded circle indicates the LJ/Coulomb force ratio for each particle.
 
 ---
 

--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -25,6 +25,8 @@ pub struct Body {
     pub species: Species,
     pub electrons: SmallVec<[Electron; 2]>,
     pub e_field: Vec2,
+    pub lj_force_debug: f32,
+    pub coulomb_force_debug: f32,
 }
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -44,6 +46,8 @@ impl Body {
             species,
             electrons: SmallVec::new(),
             e_field: Vec2::zero(),
+            lj_force_debug: 0.0,
+            coulomb_force_debug: 0.0,
         }
     }
     pub fn update_species(&mut self) {

--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -114,6 +114,16 @@ impl super::Renderer {
                 }
             }
 
+            if self.sim_config.show_lj_vs_coulomb_ratio {
+                for body in &self.bodies {
+                    let ratio = body.lj_force_debug / body.coulomb_force_debug.max(1e-6);
+                    let t = ratio / (ratio + 1.0);
+                    let r = (t * 255.0) as u8;
+                    let b = ((1.0 - t) * 255.0) as u8;
+                    ctx.draw_circle(body.pos, body.radius * 0.8, [r, 0, b, 255]);
+                }
+            }
+
 
             if let Some(body) = &self.confirmed_bodies {
                 ctx.draw_circle(body.pos, body.radius, [0xff; 4]);

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -25,7 +25,9 @@ pub fn attract(sim: &mut Simulation) {
     }
     for body in &mut sim.bodies {
         // Convert force (qE) to acceleration by dividing by mass (a = F / m)
-        body.acc = (body.charge * body.e_field) / body.mass;
+        let force = body.charge * body.e_field;
+        body.coulomb_force_debug = force.mag();
+        body.acc = force / body.mass;
 
     }
 }
@@ -88,6 +90,8 @@ pub fn apply_lj_forces(sim: &mut Simulation) {
                     // Update acceleration (SWAPPED SIGNS)
                     a.acc -= force / a.mass;
                     b.acc += force / b.mass;
+                    a.lj_force_debug += force_mag.abs();
+                    b.lj_force_debug += force_mag.abs();
 
                 }
             }

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -78,6 +78,8 @@ impl Simulation {
         self.dt = *TIMESTEP.lock();
         for body in &mut self.bodies {
             body.acc = Vec2::zero();
+            body.lj_force_debug = 0.0;
+            body.coulomb_force_debug = 0.0;
         }
 
         forces::attract(self);


### PR DESCRIPTION
## Summary
- accumulate Coulomb/LJ forces per body
- reset debug values each frame
- render a color-coded circle for LJ vs Coulomb ratio
- document the overlay in README

## Testing
- `cargo test` *(fails: failed to get `quarkstrom` dependency)*
- `cargo check --locked --offline` *(fails: can't checkout git dependency in offline mode)*

------
https://chatgpt.com/codex/tasks/task_b_684cf04be9c48332b261ec8445db7305