### PR TITLE
Fix quadtree leaf center for negative charges

### DIFF
--- a/src/quadtree/quadtree.rs
+++ b/src/quadtree/quadtree.rs
@@ -182,7 +182,11 @@ impl Quadtree {
                             }
 
                             quadtree.nodes[node].mass = total_mass;
-                            quadtree.nodes[node].pos = weighted_pos;
+                            quadtree.nodes[node].pos = if total_charge.abs() > 1e-6 {
+                                weighted_pos / total_charge
+                            } else {
+                                weighted_pos
+                            };
                             quadtree.nodes[node].charge = total_charge;
                             continue;
                         }


### PR DESCRIPTION
## Summary
- fix charge-weighted center calculation for leaf nodes

## Testing
- `cargo test --quiet` *(fails: failed to get `quarkstrom` due to network failure)*

------
https://chatgpt.com/codex/tasks/task_b_6852bd17834c8332a7935d00353ff084