### PR TITLE
Implement foil current adjustment command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ smallvec = "1.10.0"
 
 [features]
 profiling = []
+debug_quadtree = []

--- a/src/body/foil.rs
+++ b/src/body/foil.rs
@@ -1,6 +1,7 @@
 use ultraviolet::Vec2;
 
 /// Collection of fixed lithium metal particles representing a foil.
+#[derive(Clone)]
 pub struct Foil {
     /// Unique IDs of bodies that belong to this foil within `Simulation::bodies`.
     pub body_ids: Vec<u64>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::sync::atomic::Ordering;
 use crate::renderer::state::{
-    PAUSED, UPDATE_LOCK, SPAWN, BODIES, QUADTREE,
+    PAUSED, UPDATE_LOCK, SPAWN, BODIES, QUADTREE, FOILS,
 };
 
 mod body;
@@ -288,6 +288,16 @@ fn main() {
                         simulation.foils.push(crate::body::foil::Foil::new(body_ids, origin, width, height, current));
                     },
 
+                    SimCommand::SetFoilCurrent { foil_id, current } => {
+                        if let Some(foil) = simulation
+                            .foils
+                            .iter_mut()
+                            .find(|f| f.body_ids.contains(&foil_id))
+                        {
+                            foil.current = current;
+                        }
+                    },
+
                     //SimCommand::Plate { foil_id, amount } => { /* ... */ }
                     //SimCommand::Strip { foil_id, amount } => { /* ... */ }
                     //SimCommand::AddElectron { pos, vel } => { /* ... */ }
@@ -326,6 +336,11 @@ fn render(simulation: &mut Simulation) {
         let mut lock = QUADTREE.lock();
         lock.clear();
         lock.extend_from_slice(&simulation.quadtree.nodes);
+    }
+    {
+        let mut lock = FOILS.lock();
+        lock.clear();
+        lock.extend_from_slice(&simulation.foils);
     }
     *lock |= true;
 }

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -226,6 +226,29 @@ impl super::Renderer {
                     }
                 });
 
+                if let Some(selected_id) = self.selected_particle_id {
+                    let maybe_foil = {
+                        let foils = FOILS.lock();
+                        foils.iter().find(|f| f.body_ids.contains(&selected_id)).cloned()
+                    };
+                    if let Some(foil) = maybe_foil {
+                        ui.separator();
+                        ui.label("Foil Current:");
+                        let mut current = foil.current;
+                        ui.horizontal(|ui| {
+                            if ui.button("-").clicked() { current -= 1.0; }
+                            if ui.button("+").clicked() { current += 1.0; }
+                            if ui.button("0").clicked() { current = 0.0; }
+                            ui.add(egui::Slider::new(&mut current, -10.0..=10.0).step_by(0.1));
+                        });
+                        if (current - foil.current).abs() > f32::EPSILON {
+                            SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(
+                                SimCommand::SetFoilCurrent { foil_id: selected_id, current }
+                            ).unwrap();
+                        }
+                    }
+                }
+
                 // --- Debug/Diagnostics ---
                 ui.separator();
                 ui.label("Debug/Diagnostics:");

--- a/src/renderer/state.rs
+++ b/src/renderer/state.rs
@@ -14,6 +14,7 @@ pub static PAUSED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 pub static UPDATE_LOCK: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
 pub static BODIES: Lazy<Mutex<Vec<Body>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static QUADTREE: Lazy<Mutex<Vec<Node>>> = Lazy::new(|| Mutex::new(Vec::new()));
+pub static FOILS: Lazy<Mutex<Vec<crate::body::foil::Foil>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static SPAWN: Lazy<Mutex<Vec<Body>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static COLLISION_PASSES: Lazy<Mutex<usize>> = Lazy::new(|| Mutex::new(3));
 
@@ -48,6 +49,10 @@ pub enum SimCommand {
         x: f32,
         y: f32,
         particle_radius: f32,
+        current: f32,
+    },
+    SetFoilCurrent {
+        foil_id: u64,
         current: f32,
     },
     StepOnce


### PR DESCRIPTION
## Summary
- expose `FOILS` state for GUI access
- add `SetFoilCurrent` simulation command
- forward foil data to renderer and add GUI controls for foil current
- allow foils to be cloned

## Testing
- `cargo test --quiet` *(fails: failed to fetch `quarkstrom` dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68575bfef374833283e211c63284c00d