### PR TITLE
Render foil selection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::sync::atomic::Ordering;
 use crate::renderer::state::{
-    PAUSED, UPDATE_LOCK, SPAWN, BODIES, QUADTREE,
+    PAUSED, UPDATE_LOCK, SPAWN, BODIES, QUADTREE, FOILS,
 };
 
 mod body;
@@ -326,6 +326,11 @@ fn render(simulation: &mut Simulation) {
         let mut lock = QUADTREE.lock();
         lock.clear();
         lock.extend_from_slice(&simulation.quadtree.nodes);
+    }
+    {
+        let mut lock = FOILS.lock();
+        lock.clear();
+        lock.extend_from_slice(&simulation.foils);
     }
     *lock |= true;
 }

--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -16,6 +16,7 @@ impl super::Renderer {
             if *lock {
                 std::mem::swap(&mut self.bodies, &mut BODIES.lock());
                 std::mem::swap(&mut self.quadtree, &mut QUADTREE.lock());
+                std::mem::swap(&mut self.foils, &mut FOILS.lock());
             }
             if let Some(body) = self.confirmed_bodies.take() {
                 self.bodies.push(body.clone());
@@ -131,9 +132,14 @@ impl super::Renderer {
             }
 
             if let Some(id) = self.selected_particle_id {
-                if let Some(body) = self.bodies.iter().find(|b| b.id == id) {
-                    // Draw a larger, semi-transparent circle as a halo
-                    ctx.draw_circle(body.pos, body.radius * 2.0, [255, 255, 0, 128]); // yellow, semi-transparent
+                if let Some(foil) = self.foils.iter().find(|f| f.body_ids.contains(&id)) {
+                    for body in &self.bodies {
+                        if foil.body_ids.contains(&body.id) {
+                            ctx.draw_circle(body.pos, body.radius * 2.0, [255, 255, 0, 128]);
+                        }
+                    }
+                } else if let Some(body) = self.bodies.iter().find(|b| b.id == id) {
+                    ctx.draw_circle(body.pos, body.radius * 2.0, [255, 255, 0, 128]);
                 }
             }
         }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,6 +4,7 @@ pub mod gui;
 pub mod draw;
 
 use crate::body::{Body, Species};
+use crate::body::foil::Foil;
 use crate::config::SimConfig;
 use crate::quadtree::Node;
 use ultraviolet::Vec2;
@@ -22,6 +23,7 @@ pub struct Renderer {
     confirmed_bodies: Option<Body>,
     bodies: Vec<Body>,
     quadtree: Vec<Node>,
+    foils: Vec<Foil>,
     selected_particle_id: Option<u64>,
     sim_config: SimConfig,
     // Scenario controls
@@ -54,6 +56,7 @@ impl quarkstrom::Renderer for Renderer {
             confirmed_bodies: None,
             bodies: Vec::new(),
             quadtree: Vec::new(),
+            foils: Vec::new(),
             selected_particle_id: None,
             sim_config: crate::config::LJ_CONFIG.lock().clone(),
             scenario_radius: 1.0,

--- a/src/renderer/state.rs
+++ b/src/renderer/state.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{Sender};
 
 use crate::body::Body;
+use crate::body::foil::Foil;
 use crate::config;
 use crate::quadtree::Node;
 
@@ -14,6 +15,7 @@ pub static PAUSED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 pub static UPDATE_LOCK: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
 pub static BODIES: Lazy<Mutex<Vec<Body>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static QUADTREE: Lazy<Mutex<Vec<Node>>> = Lazy::new(|| Mutex::new(Vec::new()));
+pub static FOILS: Lazy<Mutex<Vec<Foil>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static SPAWN: Lazy<Mutex<Vec<Body>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static COLLISION_PASSES: Lazy<Mutex<usize>> = Lazy::new(|| Mutex::new(3));
 


### PR DESCRIPTION
## Summary
- store `Foil` structures in renderer global state
- pass `simulation.foils` to renderer state
- keep a local `foils` list in `Renderer`
- highlight the whole foil when one body is selected

## Testing
- `cargo test --quiet` *(fails: could not clone `quarkstrom`)*

------
https://chatgpt.com/codex/tasks/task_b_68575c1025ac8332965c7124b1cb8c86