### PR TITLE
Fix highlight for single selected particle

### DIFF
--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -139,6 +139,12 @@ impl super::Renderer {
                 ctx.draw_line(body.pos, body.pos + body.vel, [0xff; 4]);
             }
 
+            if let Some(id) = self.selected_particle_id {
+                if let Some(body) = self.bodies.iter().find(|b| b.id == id) {
+                    ctx.draw_circle(body.pos, body.radius * 1.1, [255, 255, 0, 32]);
+                }
+            }
+
             for id in &self.selected_particle_ids {
                 if let Some(body) = self.bodies.iter().find(|b| b.id == *id) {
                     // Draw a larger, semi-transparent circle as a halo


### PR DESCRIPTION
## Summary
- draw a highlight halo when any particle is selected, not only for foil particles

## Testing
- `cargo test` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6859f48bcf5083328963616a1090b511