### PR TITLE
Remove update_species and rely on apply_redox

### DIFF
--- a/src/body/tests.rs
+++ b/src/body/tests.rs
@@ -84,7 +84,9 @@ mod tests {
                 0.0,
                 Species::LithiumIon,
             );
-            b.update_species();
+            b.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
+            b.update_charge_from_electrons();
+            b.apply_redox();
             assert_eq!(b.species, Species::LithiumMetal);
         }
 
@@ -98,7 +100,8 @@ mod tests {
                 1.0,
                 Species::LithiumMetal,
             );
-            b.update_species();
+            b.update_charge_from_electrons();
+            b.apply_redox();
             assert_eq!(b.species, Species::LithiumIon);
         }
 

--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -48,17 +48,6 @@ impl Body {
             e_field: Vec2::zero(),
         }
     }
-    pub fn update_species(&mut self) {
-        if self.species == Species::FoilMetal || self.species == Species::ElectrolyteAnion {
-            // Don't auto-convert FoilMetal or ElectrolyteAnion to other species
-            return;
-        }
-        if self.charge > config::LITHIUM_ION_THRESHOLD {
-            self.species = Species::LithiumIon;
-        } else if self.charge <= 0.0 {
-            self.species = Species::LithiumMetal;
-        }
-    }
 
     pub fn neutral_electron_count(&self) -> usize {
         match self.species {

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
                             // Update species if charge crosses threshold
                             let was_metal = body.species == body::Species::LithiumMetal;
                             let was_ion = body.species == body::Species::LithiumIon;
-                            body.update_species();
+                            body.apply_redox();
 
                             if was_metal && body.species == body::Species::LithiumIon {
                                 println!();
@@ -128,7 +128,7 @@ fn main() {
                             body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
                         }
                         body.update_charge_from_electrons();
-                        body.update_species();
+                        body.apply_redox();
                         simulation.bodies.push(body);
                     }
 
@@ -171,7 +171,7 @@ fn main() {
                                     new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
                                 }
                                 new_body.update_charge_from_electrons();
-                                new_body.update_species();
+                                new_body.apply_redox();
                                 simulation.bodies.push(new_body);
                             }
                             r += particle_diameter;
@@ -216,7 +216,7 @@ fn main() {
                             new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
                         }
                             new_body.update_charge_from_electrons();
-                            new_body.update_species();
+                            new_body.apply_redox();
                             simulation.bodies.push(new_body);
                         }
                     },
@@ -250,7 +250,7 @@ fn main() {
                                     new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
                                 }
                                 new_body.update_charge_from_electrons();
-                                new_body.update_species();
+                                new_body.apply_redox();
                                 simulation.bodies.push(new_body);
                             }
                         }

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -337,7 +337,7 @@ pub fn make_body_with_species(pos: Vec2, vel: Vec2, mass: f32, radius: f32, spec
         }
     }
     body.update_charge_from_electrons();
-    body.update_species();
+    body.apply_redox();
     body
 }
 


### PR DESCRIPTION
## Summary
- remove the now redundant `update_species` method
- call `apply_redox` after adjusting electrons when creating or editing bodies
- update GUI helpers to use `apply_redox`
- update tests to match new behaviour

## Testing
- `cargo test --quiet` *(fails: could not fetch `quarkstrom` crate)*

------
https://chatgpt.com/codex/tasks/task_b_6859fd388a388332aab5322bf641d392