### PR TITLE
Apply redox in parallel

### DIFF
--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -296,10 +296,10 @@ impl Simulation {
         }
         let bodies_ptr = &self.bodies as *const Vec<Body>;
         let quadtree_ptr = &self.quadtree as *const Quadtree;
-        for body in &mut self.bodies {
+        self.bodies.par_iter_mut().for_each(|body| {
             let bodies = unsafe { &*bodies_ptr };
             let qt = unsafe { &*quadtree_ptr };
             body.apply_redox(bodies, qt);
-        }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- replace redox apply loop with a rayon `par_iter_mut`

## Testing
- `cargo fmt` *(fails: `cargo-fmt` not installed)*
- `cargo test` *(fails to fetch dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_b_685a0e10b77483328c4fa43a4dd761ee