### PR TITLE
Refactor neighbor search to reuse buffers

### DIFF
--- a/src/body/redox.rs
+++ b/src/body/redox.rs
@@ -26,8 +26,18 @@ impl Body {
             }
         }
     }
-    pub fn apply_redox(&mut self, bodies: &[Body], quadtree: &Quadtree) {
-        let neighbor_count = self.metal_neighbor_count(bodies, quadtree, self.radius * crate::config::HOP_RADIUS_FACTOR);
+    pub fn apply_redox(
+        &mut self,
+        bodies: &[Body],
+        quadtree: &Quadtree,
+        buffer: &mut Vec<usize>,
+    ) {
+        let neighbor_count = self.metal_neighbor_count(
+            bodies,
+            quadtree,
+            self.radius * crate::config::HOP_RADIUS_FACTOR,
+            buffer,
+        );
         match self.species {
             Species::LithiumIon => {
                 if !self.electrons.is_empty() && neighbor_count < IONIZATION_NEIGHBOR_THRESHOLD {

--- a/src/body/tests.rs
+++ b/src/body/tests.rs
@@ -64,13 +64,15 @@ mod tests {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt);
+        let mut buf = Vec::new();
+        bodies[0].apply_redox(&bodies_snapshot, &qt, &mut buf);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
         bodies[0].electrons.clear();
         bodies[0].update_charge_from_electrons();
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt);
+        let mut buf2 = Vec::new();
+        bodies[0].apply_redox(&bodies_snapshot, &qt, &mut buf2);
         assert_eq!(bodies[0].species, Species::LithiumIon);
     }
 

--- a/src/body/tests/anion.rs
+++ b/src/body/tests/anion.rs
@@ -27,7 +27,8 @@ mod electrolyte_anion {
         qt.build(&mut bodies);
         {
             let (first, rest) = bodies.split_at_mut(1);
-            first[0].apply_redox(&rest, &qt);
+            let mut buf = Vec::new();
+            first[0].apply_redox(&rest, &qt, &mut buf);
         }
         assert_eq!(bodies[0].species, Species::ElectrolyteAnion);
     }

--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -71,13 +71,19 @@ impl Body {
 
     /// Count nearby metal neighbors (LithiumMetal or FoilMetal) within `radius`
     /// using the provided quadtree.
-    pub fn metal_neighbor_count(&self, bodies: &[Body], quadtree: &crate::quadtree::Quadtree, radius: f32) -> usize {
+    pub fn metal_neighbor_count(
+        &self,
+        bodies: &[Body],
+        quadtree: &crate::quadtree::Quadtree,
+        radius: f32,
+        buffer: &mut Vec<usize>,
+    ) -> usize {
         let idx = bodies.iter().position(|b| b.id == self.id);
         if let Some(i) = idx {
-            quadtree
-                .find_neighbors_within(bodies, i, radius)
-                .into_iter()
-                .filter(|&n| matches!(bodies[n].species, Species::LithiumMetal | Species::FoilMetal))
+            quadtree.find_neighbors_within(bodies, i, radius, buffer);
+            buffer
+                .iter()
+                .filter(|&&n| matches!(bodies[n].species, Species::LithiumMetal | Species::FoilMetal))
                 .count()
         } else {
             0

--- a/src/quadtree/quadtree.rs
+++ b/src/quadtree/quadtree.rs
@@ -297,9 +297,15 @@ impl Quadtree {
     }
 
     /// Find indices of bodies within `cutoff` distance of body at index `i` (excluding `i` itself)
-    pub fn find_neighbors_within(&self, bodies: &[Body], i: usize, cutoff: f32) -> Vec<usize> {
+    pub fn find_neighbors_within(
+        &self,
+        bodies: &[Body],
+        i: usize,
+        cutoff: f32,
+        neighbors: &mut Vec<usize>,
+    ) {
         profile_scope!("quadtree_neighbors");
-        let mut neighbors = Vec::new();
+        neighbors.clear();
         let pos = bodies[i].pos;
         let cutoff_sq = cutoff * cutoff;
 
@@ -334,7 +340,6 @@ impl Quadtree {
                 }
             }
         }
-        neighbors
     }
 
     /// Compute the electric field at an arbitrary point using the quadtree (Barnes-Hut).

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -48,15 +48,17 @@ pub fn apply_lj_forces(sim: &mut Simulation) {
         sim.quadtree.build(&mut sim.bodies);
     }
 
+    let mut neighbor_buffer = Vec::new();
     for i in 0..sim.bodies.len() {
         // Only apply LJ to LithiumMetal or FoilMetal
         if !(sim.bodies[i].species == Species::LithiumMetal || sim.bodies[i].species == Species::FoilMetal) {
             continue;
         }
-        let neighbors = if use_cell {
+        let neighbors: Vec<usize> = if use_cell {
             sim.cell_list.find_neighbors_within(&sim.bodies, i, cutoff)
         } else {
-            sim.quadtree.find_neighbors_within(&sim.bodies, i, cutoff)
+            sim.quadtree.find_neighbors_within(&sim.bodies, i, cutoff, &mut neighbor_buffer);
+            neighbor_buffer.clone()
         };
         for &j in &neighbors {
             if j <= i { continue; }

--- a/src/simulation/tests.rs
+++ b/src/simulation/tests.rs
@@ -46,8 +46,9 @@ mod reactions {
         };
         sim.quadtree.build(&mut sim.bodies);
         let bodies_snapshot = sim.bodies.clone();
+        let mut buf = Vec::new();
         let b = &mut sim.bodies[0];
-        b.apply_redox(&bodies_snapshot, &sim.quadtree);
+        b.apply_redox(&bodies_snapshot, &sim.quadtree, &mut buf);
         assert_eq!(b.species, Species::LithiumMetal, "Ion with electron should become metal");
         assert_eq!(b.electrons.len(), 1, "Should have one valence electron");
         assert_eq!(b.charge, 0.0, "Neutral metal should have charge 0");
@@ -83,8 +84,9 @@ mod reactions {
         };
         sim.quadtree.build(&mut sim.bodies);
         let bodies_snapshot = sim.bodies.clone();
+        let mut buf = Vec::new();
         let b = &mut sim.bodies[0];
-        b.apply_redox(&bodies_snapshot, &sim.quadtree);
+        b.apply_redox(&bodies_snapshot, &sim.quadtree, &mut buf);
         let b = &sim.bodies[0];
         assert_eq!(b.species, Species::LithiumIon, "Metal with no electrons should become ion");
         assert_eq!(b.charge, 1.0, "Ion with no electrons should have charge +1");
@@ -114,7 +116,8 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt);
+        let mut buf = Vec::new();
+        bodies[0].apply_redox(&bodies_snapshot, &qt, &mut buf);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
         assert_eq!(bodies[0].electrons.len(), 2);
     }
@@ -140,13 +143,15 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt);
+        let mut buf = Vec::new();
+        bodies[0].apply_redox(&bodies_snapshot, &qt, &mut buf);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
         bodies[0].electrons.clear();
         bodies[0].update_charge_from_electrons();
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt);
+        let mut buf2 = Vec::new();
+        bodies[0].apply_redox(&bodies_snapshot, &qt, &mut buf2);
         assert_eq!(bodies[0].species, Species::LithiumIon);
     }
 
@@ -261,7 +266,8 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt);
+        let mut buf = Vec::new();
+        bodies[0].apply_redox(&bodies_snapshot, &qt, &mut buf);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
     }
 
@@ -291,7 +297,8 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt);
+        let mut buf = Vec::new();
+        bodies[0].apply_redox(&bodies_snapshot, &qt, &mut buf);
         assert_eq!(bodies[0].species, Species::LithiumIon);
     }
 


### PR DESCRIPTION
## Summary
- refactor `Quadtree::find_neighbors_within` to accept a mutable buffer
- pass a reusable buffer from `metal_neighbor_count`
- adjust LJ force and electron hopping code to use the new API
- update unit tests for the new parameter

## Testing
- `cargo test --quiet` *(fails: could not fetch git dependency)*

------
https://chatgpt.com/codex/tasks/task_b_685a0e3e80ec833293123ca1409b9ff6