### PR TITLE
Use field magnitude for redox

### DIFF
--- a/src/body/tests.rs
+++ b/src/body/tests.rs
@@ -64,13 +64,13 @@ mod tests {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
         bodies[0].electrons.clear();
         bodies[0].update_charge_from_electrons();
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         assert_eq!(bodies[0].species, Species::LithiumIon);
     }
 

--- a/src/body/tests/anion.rs
+++ b/src/body/tests/anion.rs
@@ -29,7 +29,7 @@ mod electrolyte_anion {
         qt.build(&mut bodies);
         {
             let (first, rest) = bodies.split_at_mut(1);
-            first[0].apply_redox(&rest, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+            first[0].apply_redox(&rest, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         }
         assert_eq!(bodies[0].species, Species::ElectrolyteAnion);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,8 @@ pub const ELECTROLYTE_ANION_NEUTRAL_ELECTRONS: usize = 1;
 pub const FOIL_MAX_ELECTRONS: usize = 2;           // Max electrons for foil metal
 /// Maximum number of nearby metallic neighbors allowed before ionization is inhibited
 pub const IONIZATION_NEIGHBOR_THRESHOLD: usize = 4;
+/// Minimum local electric-field magnitude required for ionization/reduction
+pub const IONIZATION_FIELD_THRESHOLD: f32 = 1.0e3;
 
 // ====================
 // Simulation Parameters

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -302,6 +302,7 @@ impl Simulation {
             body.apply_redox(
                 &bodies_ref,
                 quadtree_ref,
+                self.background_e_field,
                 &self.cell_list,
                 self.config.cell_list_density_threshold,
             );

--- a/src/simulation/tests.rs
+++ b/src/simulation/tests.rs
@@ -47,7 +47,7 @@ mod reactions {
         sim.quadtree.build(&mut sim.bodies);
         let bodies_snapshot = sim.bodies.clone();
         let b = &mut sim.bodies[0];
-        b.apply_redox(&bodies_snapshot, &sim.quadtree, &sim.cell_list, sim.config.cell_list_density_threshold);
+        b.apply_redox(&bodies_snapshot, &sim.quadtree, Vec2::zero(), &sim.cell_list, sim.config.cell_list_density_threshold);
         assert_eq!(b.species, Species::LithiumMetal, "Ion with electron should become metal");
         assert_eq!(b.electrons.len(), 1, "Should have one valence electron");
         assert_eq!(b.charge, 0.0, "Neutral metal should have charge 0");
@@ -84,7 +84,7 @@ mod reactions {
         sim.quadtree.build(&mut sim.bodies);
         let bodies_snapshot = sim.bodies.clone();
         let b = &mut sim.bodies[0];
-        b.apply_redox(&bodies_snapshot, &sim.quadtree, &sim.cell_list, sim.config.cell_list_density_threshold);
+        b.apply_redox(&bodies_snapshot, &sim.quadtree, Vec2::zero(), &sim.cell_list, sim.config.cell_list_density_threshold);
         let b = &sim.bodies[0];
         assert_eq!(b.species, Species::LithiumIon, "Metal with no electrons should become ion");
         assert_eq!(b.charge, 1.0, "Ion with no electrons should have charge +1");
@@ -114,7 +114,7 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
         assert_eq!(bodies[0].electrons.len(), 2);
     }
@@ -140,13 +140,13 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
         bodies[0].electrons.clear();
         bodies[0].update_charge_from_electrons();
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         assert_eq!(bodies[0].species, Species::LithiumIon);
     }
 
@@ -226,7 +226,7 @@ mod reactions {
         for b in &mut sim.bodies {
             let bodies = unsafe { &*bodies_ptr };
             let qt = unsafe { &*qt_ptr };
-            b.apply_redox(bodies, qt, &sim.cell_list, sim.config.cell_list_density_threshold);
+            b.apply_redox(bodies, qt, Vec2::zero(), &sim.cell_list, sim.config.cell_list_density_threshold);
         }
         let sum_electrons = sim.bodies.iter().map(|b| b.electrons.len()).sum::<usize>();
         assert_eq!(sum_electrons, total_electrons);
@@ -261,7 +261,7 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         assert_eq!(bodies[0].species, Species::LithiumMetal);
     }
 
@@ -291,7 +291,7 @@ mod reactions {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
         assert_eq!(bodies[0].species, Species::LithiumIon);
     }
 


### PR DESCRIPTION
## Summary
- model redox transitions based on local electric field instead of neighbor count
- add configuration constant `IONIZATION_FIELD_THRESHOLD`
- update simulation and tests for new `apply_redox` signature

## Testing
- `cargo fmt` *(fails: rustfmt component missing)*
- `cargo test --no-run` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685b5636f4088332b69e5f8b79c60e91