### PR TITLE
Implement probabilistic ion-metal redox

### DIFF
--- a/src/body/tests.rs
+++ b/src/body/tests.rs
@@ -9,6 +9,7 @@ mod tests {
     use crate::quadtree::Quadtree;
     use crate::cell_list::CellList;
     use crate::config;
+    use crate::config::SimConfig;
 
     #[test]
     fn test_body_charge_update() {
@@ -64,13 +65,29 @@ mod tests {
         );
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(
+            &bodies_snapshot,
+            &qt,
+            Vec2::zero(),
+            &CellList::new(10.0, 1.0),
+            config::LJ_CELL_DENSITY_THRESHOLD,
+            &SimConfig::default(),
+            0.1,
+        );
         assert_eq!(bodies[0].species, Species::LithiumMetal);
         bodies[0].electrons.clear();
         bodies[0].update_charge_from_electrons();
         qt.build(&mut bodies);
         let bodies_snapshot = bodies.clone();
-        bodies[0].apply_redox(&bodies_snapshot, &qt, Vec2::zero(), &CellList::new(10.0, 1.0), config::LJ_CELL_DENSITY_THRESHOLD);
+        bodies[0].apply_redox(
+            &bodies_snapshot,
+            &qt,
+            Vec2::zero(),
+            &CellList::new(10.0, 1.0),
+            config::LJ_CELL_DENSITY_THRESHOLD,
+            &SimConfig::default(),
+            0.1,
+        );
         assert_eq!(bodies[0].species, Species::LithiumIon);
     }
 

--- a/src/body/tests/anion.rs
+++ b/src/body/tests/anion.rs
@@ -3,6 +3,7 @@ mod electrolyte_anion {
     use crate::body::{Body, Species, Electron};
     use crate::quadtree::Quadtree;
     use crate::cell_list::CellList;
+    use crate::config::SimConfig;
     use ultraviolet::Vec2;
 
     #[test]
@@ -35,6 +36,8 @@ mod electrolyte_anion {
                 Vec2::zero(),
                 &CellList::new(10.0, 1.0),
                 0.0,
+                &SimConfig::default(),
+                0.1,
             );
         }
         assert_eq!(bodies[0].species, Species::ElectrolyteAnion);

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -242,11 +242,8 @@ impl Simulation {
                 .filter(|&dst_idx| dst_idx != src_idx && !received_electron[dst_idx])
                 .filter(|&dst_idx| {
                     let dst_body = &self.bodies[dst_idx];
-                    match dst_body.species {
-                        Species::LithiumMetal | Species::FoilMetal => can_transfer_electron(src_body, dst_body),
-                        Species::LithiumIon => true,
-                        Species::ElectrolyteAnion => false, // or specify logic if needed
-                    }
+                    matches!(dst_body.species, Species::LithiumMetal | Species::FoilMetal)
+                        && can_transfer_electron(src_body, dst_body)
                 })
                 .collect::<Vec<_>>();
 
@@ -305,6 +302,8 @@ impl Simulation {
                 self.background_e_field,
                 &self.cell_list,
                 self.config.cell_list_density_threshold,
+                &self.config,
+                self.dt,
             );
         });
     }


### PR DESCRIPTION
## Summary
- extend `apply_redox` with Butler–Volmer kinetics
- disallow hopping into ions and trigger redox using new probability
- update simulations and body tests for new API
- add new test verifying ion reduction via probabilistic pathway

## Testing
- `cargo test` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685c12b2d37483328edcd40d8107ee77