### PR TITLE
Restrict electron hopping to metallic neighbors

### DIFF
--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -236,17 +236,17 @@ impl Simulation {
             let hop_radius = self.config.hop_radius_factor * src_body.radius;
 
             // Use quadtree for neighbor search!
-            let mut candidate_neighbors = self.quadtree
+            let mut candidate_neighbors = self
+                .quadtree
                 .find_neighbors_within(&self.bodies, src_idx, hop_radius)
                 .into_iter()
                 .filter(|&dst_idx| dst_idx != src_idx && !received_electron[dst_idx])
                 .filter(|&dst_idx| {
                     let dst_body = &self.bodies[dst_idx];
-                    match dst_body.species {
-                        Species::LithiumMetal | Species::FoilMetal => can_transfer_electron(src_body, dst_body),
-                        Species::LithiumIon => true,
-                        Species::ElectrolyteAnion => false, // or specify logic if needed
-                    }
+                    matches!(
+                        dst_body.species,
+                        Species::LithiumMetal | Species::FoilMetal
+                    ) && can_transfer_electron(src_body, dst_body)
                 })
                 .collect::<Vec<_>>();
 

--- a/src/simulation/tests.rs
+++ b/src/simulation/tests.rs
@@ -485,7 +485,7 @@ mod reactions {
         }
 
         #[test]
-        fn butler_volmer_inter_species_hop() {
+        fn no_hop_to_ion_even_with_butler_volmer() {
             let mut metal = Body::new(Vec2::zero(), Vec2::zero(), 1.0, 1.0, 0.0, Species::LithiumMetal);
             // One extra electron to donate
             metal.electrons = smallvec![
@@ -513,6 +513,52 @@ mod reactions {
                     use_butler_volmer: true,
                     bv_exchange_current: 1e6_f32,
                     bv_overpotential_scale: 1e-8_f32,
+                    ..Default::default()
+                },
+                foils: Vec::new(),
+                cell_list: CellList::new(10.0, 1.0),
+                body_to_foil: HashMap::new(),
+            };
+            sim.quadtree.build(&mut sim.bodies);
+            let exclude = vec![false; sim.bodies.len()];
+            sim.perform_electron_hopping_with_exclusions(&exclude);
+
+            // Ion should not receive an electron
+            assert_eq!(
+                sim.bodies[0].electrons.len(),
+                crate::config::LITHIUM_METAL_NEUTRAL_ELECTRONS + 1
+            );
+            assert_eq!(sim.bodies[1].electrons.len(), 0);
+        }
+
+        #[test]
+        fn metal_hops_to_deficient_foil() {
+            let mut metal = Body::new(Vec2::zero(), Vec2::zero(), 1.0, 1.0, 0.0, Species::LithiumMetal);
+            metal.electrons = smallvec![
+                Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() };
+                crate::config::LITHIUM_METAL_NEUTRAL_ELECTRONS + 1
+            ];
+            metal.update_charge_from_electrons();
+
+            let mut foil = Body::new(Vec2::new(1.0, 0.0), Vec2::zero(), 1.0, 1.0, 0.0, Species::FoilMetal);
+            foil.electrons = SmallVec::new();
+            foil.update_charge_from_electrons();
+
+            let mut sim = Simulation {
+                dt: 0.1,
+                frame: 0,
+                bodies: vec![metal, foil],
+                quadtree: Quadtree::new(
+                    config::QUADTREE_THETA,
+                    config::QUADTREE_EPSILON,
+                    config::QUADTREE_LEAF_CAPACITY,
+                    config::QUADTREE_THREAD_CAPACITY,
+                ),
+                bounds: 10.0,
+                rewound_flags: vec![false; 2],
+                background_e_field: Vec2::zero(),
+                config: SimConfig {
+                    hop_rate_k0: 1e15_f32,
                     ..Default::default()
                 },
                 foils: Vec::new(),


### PR DESCRIPTION
## Summary
- limit electron hopping to bodies that are `LithiumMetal` or `FoilMetal`
- disallow hopping to ions even with Butler‑Volmer kinetics
- add regression test ensuring metal hops to a foil
- update inter-species hopping test to expect no transfer

## Testing
- `cargo test --no-run --quiet` *(fails: failed to fetch dependency)*

------
https://chatgpt.com/codex/tasks/task_b_685c12b3a5bc8332becaff01de9296c3