### PR TITLE
Add cached metallic neighbor info

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,14 @@ pub const FOIL_MAX_ELECTRONS: usize = 2;           // Max electrons for foil met
 //pub const IONIZATION_NEIGHBOR_THRESHOLD: usize = 4;
 /// Minimum local electric-field magnitude required for ionization/reduction
 //pub const IONIZATION_FIELD_THRESHOLD: f32 = 1.0e3;
+/// Radius factor (times body radius) for determining metal surroundings
+pub const SURROUND_RADIUS_FACTOR: f32 = 3.5;
+/// Neighbor count threshold for considering a body "surrounded" by metal
+pub const SURROUND_NEIGHBOR_THRESHOLD: usize = 4;
+/// Minimum displacement before recomputing `surrounded_by_metal`
+pub const SURROUND_MOVE_THRESHOLD: f32 = 0.5;
+/// Maximum number of frames between surround checks
+pub const SURROUND_CHECK_INTERVAL: usize = 10;
 
 // ====================
 // Simulation Parameters

--- a/src/quadtree/tests.rs
+++ b/src/quadtree/tests.rs
@@ -20,7 +20,9 @@ mod tests {
             electrons: SmallVec::new(),
             id: 0,
             e_field: Vec2::zero(),
-
+            last_surround_frame: 0,
+            last_surround_pos: Vec2::zero(),
+            surrounded_by_metal: false,
         };
         let mut bodies = vec![body];
 

--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -52,7 +52,13 @@ impl super::Renderer {
 					];*/
 
                     let color = match body.species {
-                        Species::LithiumIon => [255, 255, 0, 255],      // Yellow
+                        Species::LithiumIon => {
+                            if body.surrounded_by_metal {
+                                [255, 165, 0, 255] // orange when surrounded
+                            } else {
+                                [255, 255, 0, 255] // yellow otherwise
+                            }
+                        }
                         Species::LithiumMetal => [192, 192, 192, 255],  // Silverish
                         Species::FoilMetal => [128, 64, 0, 255],        // Brownish (example)
                         Species::ElectrolyteAnion => [0, 128, 255, 255], // Blueish for anion

--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -54,7 +54,11 @@ impl super::Renderer {
                     let color = match body.species {
                         Species::LithiumIon => {
                             if body.surrounded_by_metal {
-                                [255, 165, 0, 255] // orange when surrounded
+                                if self.show_electron_deficiency {
+                                    [255, 165, 0, 255] // orange when surrounded and deficiency visualization is on
+                                } else {
+                                    [192, 192, 192, 255] // silverish when surrounded and deficiency visualization is off
+                                }
                             } else {
                                 [255, 255, 0, 255] // yellow otherwise
                             }

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -323,8 +323,10 @@ impl Simulation {
         let quadtree = &self.quadtree;
         let cell_list = &self.cell_list;
         let frame = self.frame;
+        // Collect the data needed for immutable borrow
+        let bodies_snapshot: Vec<_> = self.bodies.iter().map(|b| b.clone()).collect();
         for (i, body) in self.bodies.iter_mut().enumerate() {
-            body.maybe_update_surrounded(i, &self.bodies, quadtree, cell_list, use_cell, frame);
+            body.maybe_update_surrounded(i, &bodies_snapshot, quadtree, cell_list, use_cell, frame);
         }
     }
 }

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -108,6 +108,7 @@ impl Simulation {
         for _ in 1..num_passes {
             collision::collide(self);
         }
+        self.update_surrounded_flags();
 
         // Track which bodies receive electrons from foil current this step
         let mut foil_current_recipients = vec![false; self.bodies.len()];
@@ -306,5 +307,24 @@ impl Simulation {
         self.bodies.par_iter_mut().for_each(|body| {
             body.apply_redox();
         });
+    }
+
+    /// Update `surrounded_by_metal` for all bodies using either the cell list or quadtree.
+    pub fn update_surrounded_flags(&mut self) {
+        if self.bodies.is_empty() { return; }
+        let use_cell = self.use_cell_list();
+        let neighbor_radius = self.config.lj_force_cutoff * self.config.lj_force_sigma;
+        if use_cell {
+            self.cell_list.cell_size = neighbor_radius;
+            self.cell_list.rebuild(&self.bodies);
+        } else {
+            self.quadtree.build(&mut self.bodies);
+        }
+        let quadtree = &self.quadtree;
+        let cell_list = &self.cell_list;
+        let frame = self.frame;
+        for (i, body) in self.bodies.iter_mut().enumerate() {
+            body.maybe_update_surrounded(i, &self.bodies, quadtree, cell_list, use_cell, frame);
+        }
     }
 }

--- a/src/simulation/tests.rs
+++ b/src/simulation/tests.rs
@@ -475,6 +475,9 @@ mod reactions {
                 electrons: SmallVec::new(),
                 id: 0,
                 e_field: Vec2::zero(),
+                last_surround_frame: 0,
+                last_surround_pos: Vec2::zero(),
+                surrounded_by_metal: false,
             };
             let bodies = vec![body];
             let config = crate::config::SimConfig::default();
@@ -559,6 +562,9 @@ mod reactions {
                 electrons: SmallVec::new(),
                 id: 0,
                 e_field: Vec2::zero(),
+                last_surround_frame: 0,
+                last_surround_pos: Vec2::zero(),
+                surrounded_by_metal: false,
             };
             
             let mut bodies = vec![body];


### PR DESCRIPTION
## Summary
- keep new `surrounded_by_metal` state on each `Body`
- update this flag periodically using either the cell list or quadtree
- render lithium ions orange when surrounded by metal

## Testing
- `cargo test --locked --offline --quiet` *(fails: can't checkout dependency in offline mode)*

------
https://chatgpt.com/codex/tasks/task_b_685d512cc7148332b9227d48bd5766ee