### PR TITLE
Reuse quadtree across simulation routines

### DIFF
--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -311,6 +311,8 @@ impl Simulation {
     }
 
     /// Update `surrounded_by_metal` for all bodies using either the cell list or quadtree.
+    ///
+    /// The provided quadtree must already be built for the current body positions.
     pub fn update_surrounded_flags(&mut self, tree: &crate::quadtree::Quadtree) {
         if self.bodies.is_empty() { return; }
         let use_cell = self.use_cell_list();


### PR DESCRIPTION
## Summary
- build the quadtree once at the beginning of each `Simulation::step`
- pass the built quadtree into `forces` routines
- reuse that quadtree when updating `surrounded` flags

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_b_685dffbefb6c83329e1441fc457e0110