### PR TITLE
Handle DPI scale factor for renderer

### DIFF
--- a/src/renderer/input.rs
+++ b/src/renderer/input.rs
@@ -55,18 +55,20 @@ impl super::Renderer {
         // Camera grab
         if input.mouse_held(2) {
             let (mdx, mdy) = input.mouse_diff();
-            self.pos.x -= mdx / height as f32 * self.scale * 2.0;
-            self.pos.y += mdy / height as f32 * self.scale * 2.0;
+            self.pos.x -= mdx / (height as f32 * self.scale_factor) * self.scale * 2.0;
+            self.pos.y += mdy / (height as f32 * self.scale_factor) * self.scale * 2.0;
         }
 
         // Mouse to world conversion
         let world_mouse = || -> Vec2 {
             let (mx, my) = input.mouse().unwrap_or_default();
+            let width_pixels = width as f32 * self.scale_factor;
+            let height_pixels = height as f32 * self.scale_factor;
             let mut mouse = Vec2::new(mx, my);
-            mouse *= 2.0 / height as f32;
+            mouse *= 2.0 / height_pixels;
             mouse.y -= 1.0;
             mouse.y *= -1.0;
-            mouse.x -= width as f32 / height as f32;
+            mouse.x -= width_pixels / height_pixels;
             mouse * self.scale + self.pos
         };
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -86,7 +86,7 @@ impl quarkstrom::Renderer for Renderer {
     fn input(&mut self, input: &WinitInputHelper, width: u16, height: u16) {
         self.window_width = width;
         self.window_height = height;
-        self.scale_factor = input.scale_factor().unwrap_or(1.0);
+        self.scale_factor = input.scale_factor().unwrap_or(1.0) as f32;
         self.handle_input(input, width, height);
     }
     fn render(&mut self, ctx: &mut quarkstrom::RenderContext) {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -12,6 +12,7 @@ use quarkstrom::winit_input_helper::WinitInputHelper;
 pub struct Renderer {
     pos: Vec2,
     scale: f32,
+    scale_factor: f32,
     settings_window_open: bool,
     show_bodies: bool,
     show_quadtree: bool,
@@ -49,6 +50,7 @@ impl quarkstrom::Renderer for Renderer {
         Self {
             pos: Vec2::zero(),
             scale: 500.0,
+            scale_factor: 1.0,
             settings_window_open: false,
             show_bodies: true,
             show_quadtree: false,
@@ -84,6 +86,7 @@ impl quarkstrom::Renderer for Renderer {
     fn input(&mut self, input: &WinitInputHelper, width: u16, height: u16) {
         self.window_width = width;
         self.window_height = height;
+        self.scale_factor = input.scale_factor().unwrap_or(1.0);
         self.handle_input(input, width, height);
     }
     fn render(&mut self, ctx: &mut quarkstrom::RenderContext) {


### PR DESCRIPTION
## Summary
- store a window `scale_factor` in `Renderer`
- update the scale factor on each input event
- adjust camera panning math to account for DPI scaling
- normalize mouse coordinates using physical pixel sizes

## Testing
- `cargo check` *(fails: failed to get `quarkstrom` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_b_685e9a9395e88332adf35892d2d3057d