### PR TITLE
Add scenario save/load functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# Ignore saved simulation states
+saved_state/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,8 @@ dependencies = [
  "quarkstrom",
  "rand 0.9.1",
  "rayon",
+ "serde",
+ "serde_json",
  "smallvec",
  "ultraviolet",
 ]
@@ -890,6 +892,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,6 +1731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1780,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1849,9 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -1990,6 +2039,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a28554d13eb5daba527cc1b91b6c341372a0ae45ed277ffb2c6fbc04f319d7e"
 dependencies = [
+ "serde",
  "wide",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,14 @@ parking_lot = "0.12.3"
 once_cell = "1.20.1"
 
 serde = { version = "1.0", features = ["derive"] }
+
 serde_json = "1.0"
 
 rayon = "1.10.0"
 crossbeam = "0.8.4"
 broccoli-rayon = "0.4.0"
 rand = "0.9.1"
-smallvec = "1.10.0"
+smallvec = { version = "1.10.0", features = ["serde"] }
 
 [features]
 profiling = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,16 @@ edition = "2021"
 [dependencies]
 quarkstrom = { git = "https://github.com/DeadlockCode/quarkstrom", rev = "8aa27dba1739f09b4d1372faa8553e64a3f0549d" }
 
-ultraviolet = "0.9.2"
+ultraviolet = { version = "0.9.2", features = ["serde"] }
 fastrand = "2.1.1"
 broccoli = "6.3.0"
 palette = "0.7.6"
 
 parking_lot = "0.12.3"
 once_cell = "1.20.1"
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 rayon = "1.10.0"
 crossbeam = "0.8.4"

--- a/src/body/electron.rs
+++ b/src/body/electron.rs
@@ -3,8 +3,9 @@
 
 use ultraviolet::Vec2;
 use crate::config;
+use serde::{Serialize, Deserialize};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Electron {
     pub rel_pos: Vec2,
     pub vel: Vec2,

--- a/src/body/foil.rs
+++ b/src/body/foil.rs
@@ -1,10 +1,11 @@
 use ultraviolet::Vec2;
 use std::sync::atomic::{AtomicU64, Ordering};
+use serde::{Serialize, Deserialize};
 
 //static NEXT_FOIL_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Mode describing how currents are linked between foils.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LinkMode {
     /// Currents have the same sign and magnitude.
     Parallel,
@@ -13,7 +14,7 @@ pub enum LinkMode {
 }
 
 /// Collection of fixed lithium metal particles representing a foil.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Foil {
     /// Unique identifier for this foil.
     pub id: u64,

--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -5,8 +5,9 @@ use ultraviolet::Vec2;
 use crate::config;
 use super::electron::Electron;
 use smallvec::SmallVec;
+use serde::{Serialize, Deserialize};
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum Species {
     LithiumIon,
     LithiumMetal,
@@ -14,8 +15,7 @@ pub enum Species {
     ElectrolyteAnion,
 }
 
-#[derive(Clone)]
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Body {
     pub pos: Vec2,
     pub vel: Vec2,

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,14 +94,16 @@ pub const SHOW_VELOCITY_VECTORS: bool = false;      /// Show velocity vectors
 pub const SHOW_CHARGE_DENSITY: bool = false;      /// Show charge-density heatmap
 pub const SHOW_FIELD_VECTORS: bool = false; // Show electric field vectors
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IsolineFieldMode {
     Total,
     ExternalOnly,
     BodyOnly,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimConfig {
     pub hop_rate_k0: f32,
     pub hop_transfer_coeff: f32,

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,47 @@
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::simulation::Simulation;
+use crate::body::{Body, foil::Foil};
+use crate::config::SimConfig;
+
+#[derive(Serialize, Deserialize)]
+pub struct SimulationState {
+    pub bodies: Vec<Body>,
+    pub foils: Vec<Foil>,
+    pub body_to_foil: HashMap<u64, u64>,
+    pub config: SimConfig,
+}
+
+impl SimulationState {
+    pub fn from_simulation(sim: &Simulation) -> Self {
+        Self {
+            bodies: sim.bodies.clone(),
+            foils: sim.foils.clone(),
+            body_to_foil: sim.body_to_foil.clone(),
+            config: sim.config.clone(),
+        }
+    }
+
+    pub fn apply_to(self, sim: &mut Simulation) {
+        sim.bodies = self.bodies;
+        sim.foils = self.foils;
+        sim.body_to_foil = self.body_to_foil;
+        sim.config = self.config;
+        sim.quadtree.build(&mut sim.bodies);
+        sim.cell_list.rebuild(&sim.bodies);
+    }
+}
+
+pub fn save_state<P: AsRef<Path>>(path: P, sim: &Simulation) -> std::io::Result<()> {
+    let state = SimulationState::from_simulation(sim);
+    let json = serde_json::to_string_pretty(&state).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    std::fs::write(path, json)
+}
+
+pub fn load_state<P: AsRef<Path>>(path: P) -> std::io::Result<SimulationState> {
+    let data = std::fs::read_to_string(path)?;
+    let state: SimulationState = serde_json::from_str(&data).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    Ok(state)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod simulation;
 mod utils;
 mod config;
 mod profiler;
+mod io;
 
 use crate::body::Species;
 //use crate::body::foil::{Foil, LinkMode};
@@ -25,6 +26,7 @@ use std::sync::mpsc::channel;
 use simulation::Simulation;
 use crate::body::Electron;
 use ultraviolet::Vec2;
+use crate::io::{save_state, load_state, SimulationState};
 
 #[cfg(feature = "profiling")]   
 use once_cell::sync::Lazy;
@@ -189,6 +191,19 @@ fn main() {
                         }
                         // Optionally, pause the simulation if desired:
                         PAUSED.store(true, Ordering::Relaxed);
+                    },
+
+                    SimCommand::SaveState { path } => {
+                        if let Err(e) = save_state(path, &simulation) {
+                            eprintln!("Failed to save state: {}", e);
+                        }
+                    },
+
+                    SimCommand::LoadState { path } => {
+                        match load_state(path) {
+                            Ok(state) => state.apply_to(&mut simulation),
+                            Err(e) => eprintln!("Failed to load state: {}", e),
+                        }
                     },
 
                     SimCommand::AddRing { body, x, y, radius } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use std::sync::mpsc::channel;
 use simulation::Simulation;
 use crate::body::Electron;
 use ultraviolet::Vec2;
-use crate::io::{save_state, load_state, SimulationState};
+use crate::io::{save_state, load_state};
 
 #[cfg(feature = "profiling")]   
 use once_cell::sync::Lazy;

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -252,6 +252,25 @@ impl super::Renderer {
                             }).unwrap();
                         }
                     });
+
+                    ui.horizontal(|ui| {
+                        if ui.button("Save State").clicked() {
+                            SIM_COMMAND_SENDER
+                                .lock()
+                                .as_ref()
+                                .unwrap()
+                                .send(SimCommand::SaveState { path: "state.json".into() })
+                                .unwrap();
+                        }
+                        if ui.button("Load State").clicked() {
+                            SIM_COMMAND_SENDER
+                                .lock()
+                                .as_ref()
+                                .unwrap()
+                                .send(SimCommand::LoadState { path: "state.json".into() })
+                                .unwrap();
+                        }
+                    });
                 });
 
                 // --- Foil Current Controls for Selected Foil ---

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -43,6 +43,10 @@ pub struct Renderer {
     pub window_width: u16,
     pub window_height: u16,
     pub show_electron_deficiency: bool,
+    // State saving/loading UI
+    pub save_state_name: String,
+    pub load_state_selected: Option<String>,
+    pub save_state_counter: usize,
 }
 
 impl quarkstrom::Renderer for Renderer {
@@ -80,6 +84,9 @@ impl quarkstrom::Renderer for Renderer {
             window_width: 800, // default value, can be changed
             window_height: 600, // default value, can be changed
             show_electron_deficiency: true,
+            save_state_name: String::new(),
+            load_state_selected: None,
+            save_state_counter: 1,
         }
     }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -46,7 +46,6 @@ pub struct Renderer {
     // State saving/loading UI
     pub save_state_name: String,
     pub load_state_selected: Option<String>,
-    pub save_state_counter: usize,
 }
 
 impl quarkstrom::Renderer for Renderer {
@@ -86,7 +85,6 @@ impl quarkstrom::Renderer for Renderer {
             show_electron_deficiency: true,
             save_state_name: String::new(),
             load_state_selected: None,
-            save_state_counter: 1,
         }
     }
 

--- a/src/renderer/state.rs
+++ b/src/renderer/state.rs
@@ -58,6 +58,8 @@ pub enum SimCommand {
         foil_id: u64,
         current: f32,
     },
+    SaveState { path: String },
+    LoadState { path: String },
     StepOnce
 }
 


### PR DESCRIPTION
## Summary
- add serde features to Cargo dependencies
- add `SimulationState` and helper functions to save/load JSON
- derive serde traits for core structs
- add buttons for saving/loading state in the GUI
- extend `SimCommand` and handle save/load events

## Testing
- `cargo test --quiet` *(fails: failed to fetch git dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685eb4c6a4f88332b39b74ec37be62e6