### PR TITLE
Use Quadtree helpers for field calculation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -368,8 +368,18 @@ fn render(simulation: &mut Simulation) {
     }
     {
         let mut lock = QUADTREE.lock();
-        lock.clear();
-        lock.extend_from_slice(&simulation.quadtree.nodes);
+        lock.nodes.clear();
+        lock.nodes.extend_from_slice(&simulation.quadtree.nodes);
+        lock.parents.clear();
+        lock.parents.extend_from_slice(&simulation.quadtree.parents);
+        lock.t_sq = simulation.quadtree.t_sq;
+        lock.e_sq = simulation.quadtree.e_sq;
+        lock.leaf_capacity = simulation.quadtree.leaf_capacity;
+        lock.thread_capacity = simulation.quadtree.thread_capacity;
+        lock.atomic_len.store(
+            simulation.quadtree.atomic_len.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
     }
     {
         let mut lock = FOILS.lock();

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -5,7 +5,7 @@ pub mod draw;
 
 use crate::body::{Body, Species, foil::Foil};
 use crate::config::SimConfig;
-use crate::quadtree::Node;
+use crate::quadtree::Quadtree;
 use ultraviolet::Vec2;
 use quarkstrom::winit_input_helper::WinitInputHelper;
 
@@ -21,7 +21,7 @@ pub struct Renderer {
     total: Option<f32>,
     confirmed_bodies: Option<Body>,
     bodies: Vec<Body>,
-    quadtree: Vec<Node>,
+    quadtree: Quadtree,
     foils: Vec<Foil>,
     selected_particle_id: Option<u64>,
     //foils: Vec<crate::body::foil::Foil>,
@@ -59,7 +59,12 @@ impl quarkstrom::Renderer for Renderer {
             total: None,
             confirmed_bodies: None,
             bodies: Vec::new(),
-            quadtree: Vec::new(),
+            quadtree: Quadtree::new(
+                crate::config::QUADTREE_THETA,
+                crate::config::QUADTREE_EPSILON,
+                crate::config::QUADTREE_LEAF_CAPACITY,
+                crate::config::QUADTREE_THREAD_CAPACITY,
+            ),
             foils: Vec::new(),
             selected_particle_id: None,
             //foils: Vec::new(),

--- a/src/renderer/state.rs
+++ b/src/renderer/state.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::{Sender};
 use crate::body::Body;
 use crate::body::foil::{Foil, LinkMode};
 use crate::config;
-use crate::quadtree::Node;
+use crate::quadtree::Quadtree;
 
 pub static TIMESTEP: Lazy<Mutex<f32>> = Lazy::new(|| Mutex::new(config::DEFAULT_DT));
 pub static FIELD_MAGNITUDE: Lazy<Mutex<f32>> = Lazy::new(|| Mutex::new(0.0));
@@ -14,7 +14,14 @@ pub static FIELD_DIRECTION: Lazy<Mutex<f32>> = Lazy::new(|| Mutex::new(180.0));
 pub static PAUSED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 pub static UPDATE_LOCK: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
 pub static BODIES: Lazy<Mutex<Vec<Body>>> = Lazy::new(|| Mutex::new(Vec::new()));
-pub static QUADTREE: Lazy<Mutex<Vec<Node>>> = Lazy::new(|| Mutex::new(Vec::new()));
+pub static QUADTREE: Lazy<Mutex<Quadtree>> = Lazy::new(|| {
+    Mutex::new(Quadtree::new(
+        config::QUADTREE_THETA,
+        config::QUADTREE_EPSILON,
+        config::QUADTREE_LEAF_CAPACITY,
+        config::QUADTREE_THREAD_CAPACITY,
+    ))
+});
 pub static FOILS: Lazy<Mutex<Vec<Foil>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static SPAWN: Lazy<Mutex<Vec<Body>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static COLLISION_PASSES: Lazy<Mutex<usize>> = Lazy::new(|| Mutex::new(3));


### PR DESCRIPTION
## Summary
- add a `potential_at_point` helper on `Quadtree`
- update field and potential helpers in the renderer to use `Quadtree`
- store a full `Quadtree` in renderer state
- copy simulation quadtree data for rendering

## Testing
- `cargo build --locked --offline` *(fails: can't fetch `quarkstrom`)*
- `cargo test --locked --offline` *(fails: can't fetch `quarkstrom`)*

------
https://chatgpt.com/codex/tasks/task_b_685eb51d284883328dcbdeb0fc903e4d