### PR TITLE
Add species defaults map

### DIFF
--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -4,10 +4,12 @@
 use ultraviolet::Vec2;
 use crate::config;
 use super::electron::Electron;
+use crate::species::{SPECIES_PROPERTIES, SpeciesProps};
 use smallvec::SmallVec;
 use serde::{Serialize, Deserialize};
+use std::hash::Hash;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 pub enum Species {
     LithiumIon,
     LithiumMetal,
@@ -136,5 +138,25 @@ impl Body {
             self.last_surround_pos = self.pos;
             self.last_surround_frame = frame;
         }
+    }
+}
+
+impl Species {
+    fn props(&self) -> &'static SpeciesProps {
+        SPECIES_PROPERTIES
+            .get(self)
+            .expect("missing species properties")
+    }
+
+    pub fn mass(&self) -> f32 {
+        self.props().mass
+    }
+
+    pub fn radius(&self) -> f32 {
+        self.props().radius
+    }
+
+    pub fn damping(&self) -> f32 {
+        self.props().damping
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod utils;
 mod config;
 mod profiler;
 mod io;
+mod species;
 
 use crate::body::Species;
 //use crate::body::foil::{Foil, LinkMode};
@@ -63,9 +64,30 @@ fn main() {
     let left_center = Vec2::new(-bounds * 0.6, 0.0);
     let right_center = Vec2::new(bounds * 0.6, 0.0);
     let center = Vec2::zero();
-    let metal_body = crate::body::Body::new(Vec2::zero(), Vec2::zero(), 1.0, 1.0, 0.0, Species::LithiumMetal);
-    let ion_body = crate::body::Body::new(Vec2::zero(), Vec2::zero(), 1.0, 1.0, 1.0, Species::LithiumIon);
-    let anion_body = crate::body::Body::new(Vec2::zero(), Vec2::zero(), 1.0, 1.0, -1.0, Species::ElectrolyteAnion);
+    let metal_body = crate::body::Body::new(
+        Vec2::zero(),
+        Vec2::zero(),
+        Species::LithiumMetal.mass(),
+        Species::LithiumMetal.radius(),
+        0.0,
+        Species::LithiumMetal,
+    );
+    let ion_body = crate::body::Body::new(
+        Vec2::zero(),
+        Vec2::zero(),
+        Species::LithiumIon.mass(),
+        Species::LithiumIon.radius(),
+        1.0,
+        Species::LithiumIon,
+    );
+    let anion_body = crate::body::Body::new(
+        Vec2::zero(),
+        Vec2::zero(),
+        Species::ElectrolyteAnion.mass(),
+        Species::ElectrolyteAnion.radius(),
+        -1.0,
+        Species::ElectrolyteAnion,
+    );
     // Send SimCommands to populate the simulation
     let tx = SIM_COMMAND_SENDER.lock().as_ref().unwrap().clone();
     tx.send(SimCommand::AddCircle { body: metal_body.clone(), x: left_center.x, y: left_center.y, radius: clump_radius }).unwrap();
@@ -290,7 +312,7 @@ fn main() {
                                 let mut new_body = crate::body::Body::new(
                                     pos,
                                     Vec2::zero(),
-                                    1e6, // Large mass for foil
+                                    Species::FoilMetal.mass(),
                                     particle_radius,
                                     0.0,
                                     Species::FoilMetal,

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -178,12 +178,13 @@ impl super::Renderer {
                         ui.label("Radius:");
                         ui.add(egui::DragValue::new(&mut self.scenario_radius).speed(0.1));
                         if ui.button("Add Ring").clicked() {
+                            let spec = self.scenario_species;
                             let body = make_body_with_species(
                                 ultraviolet::Vec2::zero(),
                                 ultraviolet::Vec2::zero(),
-                                1.0,
+                                spec.mass(),
                                 self.scenario_particle_radius,
-                                self.scenario_species,
+                                spec,
                             );
                             SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(SimCommand::AddRing {
                                 body,
@@ -193,12 +194,13 @@ impl super::Renderer {
                             }).unwrap();
                         }
                         if ui.button("Add Filled Circle").clicked() {
+                            let spec = self.scenario_species;
                             let body = make_body_with_species(
                                 ultraviolet::Vec2::zero(),
                                 ultraviolet::Vec2::zero(),
-                                1.0,
+                                spec.mass(),
                                 self.scenario_particle_radius,
-                                self.scenario_species,
+                                spec,
                             );
                             SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(SimCommand::AddCircle {
                                 body,
@@ -216,12 +218,13 @@ impl super::Renderer {
                         ui.label("Height:");
                         ui.add(egui::DragValue::new(&mut self.scenario_height).speed(0.1));
                         if ui.button("Add Rectangle").clicked() {
+                            let spec = self.scenario_species;
                             let body = make_body_with_species(
                                 ultraviolet::Vec2::zero(),
                                 ultraviolet::Vec2::zero(),
-                                1.0,
+                                spec.mass(),
                                 self.scenario_particle_radius,
-                                self.scenario_species,
+                                spec,
                             );
                             SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(SimCommand::AddRectangle {
                                 body,

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -45,7 +45,7 @@ impl super::Renderer {
                 // --- Simulation Controls ---
                 egui::CollapsingHeader::new("Simulation Controls").default_open(true).show(ui, |ui| {
                     ui.add(
-                        egui::Slider::new(&mut *TIMESTEP.lock(), 0.0001..=0.01)
+                        egui::Slider::new(&mut *TIMESTEP.lock(), 0.0001..=0.1)
                             .text("Timestep (dt)")
                             .step_by(0.001),
                     );
@@ -158,18 +158,26 @@ impl super::Renderer {
 
                     // Common controls for all Add scenarios
                     ui.horizontal(|ui| {
+                        use crate::species::SPECIES_PROPERTIES;
                         ui.label("X:");
                         ui.add(egui::DragValue::new(&mut self.scenario_x).speed(0.1));
                         ui.label("Y:");
                         ui.add(egui::DragValue::new(&mut self.scenario_y).speed(0.1));
                         ui.label("Particle Radius:");
+                        // Set default radius from species if changed
+                        if let Some(props) = SPECIES_PROPERTIES.get(&self.scenario_species) {
+                            if (self.scenario_particle_radius - props.radius).abs() > f32::EPSILON && ui.button("Reset to Default").clicked() {
+                                self.scenario_particle_radius = props.radius;
+                            }
+                        }
                         ui.add(egui::DragValue::new(&mut self.scenario_particle_radius).speed(0.05));
                         egui::ComboBox::from_label("Species")
                             .selected_text(format!("{:?}", self.scenario_species))
                             .show_ui(ui, |ui| {
-                                ui.selectable_value(&mut self.scenario_species, Species::LithiumMetal, "Metal");
-                                ui.selectable_value(&mut self.scenario_species, Species::LithiumIon, "Ion");
-                                ui.selectable_value(&mut self.scenario_species, Species::ElectrolyteAnion, "Anion");
+                                use crate::renderer::Species;
+                                ui.selectable_value(&mut self.scenario_species, Species::LithiumMetal, "Lithium Metal");
+                                ui.selectable_value(&mut self.scenario_species, Species::LithiumIon, "Lithium Ion");
+                                ui.selectable_value(&mut self.scenario_species, Species::ElectrolyteAnion, "Electrolyte Anion");
                             });
                     });
 
@@ -179,11 +187,12 @@ impl super::Renderer {
                         ui.add(egui::DragValue::new(&mut self.scenario_radius).speed(0.1));
                         if ui.button("Add Ring").clicked() {
                             let spec = self.scenario_species;
+                            let props = crate::species::SPECIES_PROPERTIES.get(&spec).unwrap();
                             let body = make_body_with_species(
                                 ultraviolet::Vec2::zero(),
                                 ultraviolet::Vec2::zero(),
-                                spec.mass(),
-                                self.scenario_particle_radius,
+                                props.mass,
+                                props.radius,
                                 spec,
                             );
                             SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(SimCommand::AddRing {
@@ -195,11 +204,12 @@ impl super::Renderer {
                         }
                         if ui.button("Add Filled Circle").clicked() {
                             let spec = self.scenario_species;
+                            let props = crate::species::SPECIES_PROPERTIES.get(&spec).unwrap();
                             let body = make_body_with_species(
                                 ultraviolet::Vec2::zero(),
                                 ultraviolet::Vec2::zero(),
-                                spec.mass(),
-                                self.scenario_particle_radius,
+                                props.mass,
+                                props.radius,
                                 spec,
                             );
                             SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(SimCommand::AddCircle {
@@ -219,11 +229,12 @@ impl super::Renderer {
                         ui.add(egui::DragValue::new(&mut self.scenario_height).speed(0.1));
                         if ui.button("Add Rectangle").clicked() {
                             let spec = self.scenario_species;
+                            let props = crate::species::SPECIES_PROPERTIES.get(&spec).unwrap();
                             let body = make_body_with_species(
                                 ultraviolet::Vec2::zero(),
                                 ultraviolet::Vec2::zero(),
-                                spec.mass(),
-                                self.scenario_particle_radius,
+                                props.mass,
+                                props.radius,
                                 spec,
                             );
                             SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(SimCommand::AddRectangle {

--- a/src/renderer/input.rs
+++ b/src/renderer/input.rs
@@ -120,12 +120,13 @@ impl super::Renderer {
                 } else {
                     // Spawning logic (no shift)
                     let mouse = world_mouse();
+                    let spec = self.scenario_species;
                     let body = crate::renderer::gui::make_body_with_species(
                         mouse,
                         Vec2::zero(),
-                        1.0,
-                        1.0,
-                        self.scenario_species,
+                        spec.mass(),
+                        spec.radius(),
+                        spec,
                     );
                     self.spawn_body = Some(body);
                     self.angle = None;

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -186,10 +186,11 @@ impl Simulation {
         profile_scope!("iterate");
         // Damping factor scales with timestep and is user-configurable
         let dt = self.dt;
-        let damping = self.config.damping_base.powf(dt / 0.01);
+        let base_damping = self.config.damping_base.powf(dt / 0.01);
         let bounds = self.bounds;
         self.bodies.par_iter_mut().for_each(|body| {
             body.vel += body.acc * dt;
+            let damping = base_damping * body.species.damping();
             body.vel *= damping;
             body.pos += body.vel * dt;
             for axis in 0..2 {

--- a/src/species.rs
+++ b/src/species.rs
@@ -16,7 +16,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
     m.insert(LithiumIon, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
     m.insert(LithiumMetal, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
     m.insert(FoilMetal, SpeciesProps { mass: 1e6, radius: 1.0, damping: 1.0 });
-    m.insert(ElectrolyteAnion, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
+    m.insert(ElectrolyteAnion, SpeciesProps { mass: 40.0, radius: 1.5, damping: 1.0 });
     m
 });
 

--- a/src/species.rs
+++ b/src/species.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+use once_cell::sync::Lazy;
+
+use crate::body::Species;
+
+#[derive(Clone, Copy, Debug)]
+pub struct SpeciesProps {
+    pub mass: f32,
+    pub radius: f32,
+    pub damping: f32,
+}
+
+pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(|| {
+    use Species::*;
+    let mut m = HashMap::new();
+    m.insert(LithiumIon, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
+    m.insert(LithiumMetal, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
+    m.insert(FoilMetal, SpeciesProps { mass: 1e6, radius: 1.0, damping: 1.0 });
+    m.insert(ElectrolyteAnion, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
+    m
+});
+


### PR DESCRIPTION
## Summary
- centralize per-species default properties in a new `species` module
- expose helper methods `Species::mass()`, `radius()` and `damping()`
- apply per-species damping during simulation iteration
- use species defaults when spawning new bodies

## Testing
- `cargo test --quiet` *(fails: failed to fetch `quarkstrom` git dependency)*

------
https://chatgpt.com/codex/tasks/task_b_686065ca16e083329601825d1d836853