### PR TITLE
Add soft wall repulsion

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,8 @@ pub const QUADTREE_THREAD_CAPACITY: usize = 1024;       // Max bodies per thread
 // ====================
 pub const CLUMP_RADIUS: f32 = 20.0;                     // Radius of each clump
 pub const DOMAIN_BOUNDS: f32 = 350.0;                   // Simulation domain boundary
+/// Spring constant for the soft wall repulsion force
+pub const WALL_REPULSION_K: f32 = 50.0;
 
 // ====================
 // Threading/Parallelism

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -192,15 +192,18 @@ impl Simulation {
             body.vel += body.acc * dt;
             body.vel *= damping;
             body.pos += body.vel * dt;
+            let k = config::WALL_REPULSION_K;
             for axis in 0..2 {
                 let pos = if axis == 0 { &mut body.pos.x } else { &mut body.pos.y };
                 let vel = if axis == 0 { &mut body.vel.x } else { &mut body.vel.y };
-                if *pos < -bounds {
-                    *pos = -bounds;
-                    *vel = -*vel;
-                } else if *pos > bounds {
-                    *pos = bounds;
-                    *vel = -*vel;
+                let dist_to_wall = bounds - pos.abs();
+                if dist_to_wall < body.radius {
+                    let penetration = body.radius - dist_to_wall;
+                    let dir = -pos.signum();
+                    *vel += dir * k * penetration * dt / body.mass;
+                    if pos.abs() > bounds {
+                        *pos = pos.signum() * bounds;
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Summary
- add a repulsion constant for boundary walls
- apply soft wall force rather than velocity reversal when hitting bounds

## Testing
- `cargo test` *(fails: failed to fetch dependencies)*
- `cargo fmt -- --check` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6860661b5ad883328cc4bf3482d47151