### PR TITLE
Add foil frequency control

### DIFF
--- a/src/body/foil.rs
+++ b/src/body/foil.rs
@@ -24,6 +24,8 @@ pub struct Foil {
     pub current: f32,
     /// Internal accumulator used to emit/remove fractional electrons per step.
     pub accum: f32,
+    /// Frequency in Hz for toggling current direction.
+    pub switch_hz: f32,
     /// Identifier of a linked foil, if any.
     pub link_id: Option<u64>,
     /// Link mode describing how the currents are related.
@@ -38,6 +40,7 @@ impl Foil {
             body_ids,
             current,
             accum: 0.0,
+            switch_hz: 0.0,
             link_id: None,
             mode: LinkMode::Parallel,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,6 +341,16 @@ fn main() {
                         }
                     },
 
+                    SimCommand::SetFoilFrequency { foil_id, freq } => {
+                        if let Some(foil) = simulation
+                            .foils
+                            .iter_mut()
+                            .find(|f| f.body_ids.contains(&foil_id))
+                        {
+                            foil.switch_hz = freq;
+                        }
+                    },
+
                     SimCommand::LinkFoils { a, b, mode } => {
                         let a_idx = simulation.foils.iter().position(|f| f.id == a);
                         let b_idx = simulation.foils.iter().position(|f| f.id == b);

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -357,6 +357,17 @@ impl super::Renderer {
                                     SimCommand::SetFoilCurrent { foil_id: selected_id, current }
                                 ).unwrap();
                             }
+
+                            let mut freq = foil.switch_hz;
+                            ui.horizontal(|ui| {
+                                ui.label("Switch Hz:");
+                                ui.add(egui::DragValue::new(&mut freq).speed(0.1));
+                            });
+                            if (freq - foil.switch_hz).abs() > f32::EPSILON {
+                                SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(
+                                    SimCommand::SetFoilFrequency { foil_id: selected_id, freq }
+                                ).unwrap();
+                            }
                         });
                     }
                 }

--- a/src/renderer/state.rs
+++ b/src/renderer/state.rs
@@ -58,6 +58,10 @@ pub enum SimCommand {
         foil_id: u64,
         current: f32,
     },
+    SetFoilFrequency {
+        foil_id: u64,
+        freq: f32,
+    },
     SaveState { path: String },
     LoadState { path: String },
     StepOnce


### PR DESCRIPTION
## Summary
- allow foils to store a switch frequency
- expose frequency via new `SimCommand::SetFoilFrequency`
- update main simulation loop to handle the command
- provide GUI slider to edit a foil's switching frequency

## Testing
- `cargo check` *(fails: failed to fetch quarkstrom dependency)*

------
https://chatgpt.com/codex/tasks/task_b_686096570b708332bfa9fc076d07fe99