### PR TITLE
Add axis bound controls for plots

### DIFF
--- a/src/plotting/mod.rs
+++ b/src/plotting/mod.rs
@@ -42,6 +42,10 @@ pub struct PlotConfig {
     pub spatial_bins: usize,
     pub time_window: f32, // seconds
     pub update_frequency: f32, // Hz
+    pub x_min: Option<f64>,
+    pub x_max: Option<f64>,
+    pub y_min: Option<f64>,
+    pub y_max: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## Summary
- extend `PlotConfig` with optional axis bounds
- allow setting x/y bounds when creating new plots
- switch plotting to egui::plot and honor custom bounds
- provide UI controls to edit bounds per plot

## Testing
- `cargo check --offline` *(fails: failed to get `quarkstrom` due to offline mode)*

------
https://chatgpt.com/codex/tasks/task_b_686344dfed98833294a0e215cfd71c66