### PR TITLE
Support dendrite formation rate plots

### DIFF
--- a/PLOTTING_FEATURES.md
+++ b/PLOTTING_FEATURES.md
@@ -61,6 +61,7 @@ The particle simulation now includes a comprehensive plotting and analysis syste
 - **Foil Current**: Current through specific foils
 - **Electron Hop Rate**: Rate of electron transfer events
 - **Local Field Strength**: Electric field strength at positions
+- **Dendrite Formation Rate**: Rate of Li+ to Li metal transitions
 
 ### 3. Sampling Modes
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains a modular, parallelized particle simulation for large-s
   - Lithium ions (Li⁺) and lithium metal (Li) dynamically update their species based on electron count.
   - Electron hopping with strict conservation rules and distance-dependent rates.
 - **Real-time Data Analysis & Plotting**:
-  - **Time Series Plots**: Track species populations, foil currents, and electron hop rates over time.
+  - **Time Series Plots**: Track species populations, foil currents, electron hop rates, and dendrite formation rates over time.
   - **Spatial Profile Plots**: Analyze charge distribution, velocity profiles, and electron counts along X or Y axes.
   - **Full Domain Binning**: Spatial plots always span the entire simulation domain (-350 to +350), regardless of particle locations.
   - **Data Export**: Export plot data in CSV, JSON, or TSV formats for external analysis.
@@ -104,6 +104,7 @@ The simulation includes a comprehensive plotting system for real-time data analy
   - Species population tracking (Li+, Li metal, anions)
   - Foil current monitoring
   - Electron hop rate analysis
+  - Dendrite formation rate tracking
 
 - **Spatial Profile Plots**:
   - Charge distribution along X or Y axes

--- a/src/plotting/gui.rs
+++ b/src/plotting/gui.rs
@@ -262,6 +262,7 @@ fn show_quantity_selector(ui: &mut egui::Ui, quantity: &mut Quantity, plot_type:
             if matches!(plot_type, PlotType::TimeSeries) {
                 ui.selectable_value(quantity, Quantity::FoilCurrent(1), "Foil Current (ID 1)");
                 ui.selectable_value(quantity, Quantity::ElectronHopRate, "Electron Hop Rate");
+                ui.selectable_value(quantity, Quantity::DendriteFormationRate, "Dendrite Formation Rate");
             }
             
             // Spatial quantities only
@@ -274,7 +275,7 @@ fn show_quantity_selector(ui: &mut egui::Ui, quantity: &mut Quantity, plot_type:
 fn is_quantity_compatible_with_plot_type(quantity: &Quantity, plot_type: &PlotType) -> bool {
     match quantity {
         // These quantities only make sense for time series
-        Quantity::FoilCurrent(_) | Quantity::ElectronHopRate => {
+        Quantity::FoilCurrent(_) | Quantity::ElectronHopRate | Quantity::DendriteFormationRate => {
             matches!(plot_type, PlotType::TimeSeries)
         }
         // Local field strength is only meaningful for spatial plots
@@ -549,6 +550,7 @@ fn get_axis_labels(config: &crate::plotting::PlotConfig) -> (&'static str, &'sta
         Quantity::FoilCurrent(_) => "Current (A)",
         Quantity::ElectronHopRate => "Hop Rate (1/s)",
         Quantity::LocalFieldStrength => "Field Strength",
+        Quantity::DendriteFormationRate => "Formation Rate (1/s)",
     };
     
     (x_label, y_label)

--- a/src/plotting/tests.rs
+++ b/src/plotting/tests.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::body::{Body, Species};
+    use ultraviolet::Vec2;
+    use crate::body::foil::Foil;
+
+    #[test]
+    fn dendrite_rate_counts_transitions() {
+        let mut plotting = PlottingSystem::new(1.0);
+        let config = PlotConfig {
+            plot_type: PlotType::TimeSeries,
+            quantity: Quantity::DendriteFormationRate,
+            title: "rate".to_string(),
+            sampling_mode: SamplingMode::SingleTimestep,
+            spatial_bins: 10,
+            time_window: 10.0,
+            update_frequency: 1.0,
+        };
+        let window_id = plotting.create_plot_window(config);
+
+        // Initial ion
+        let mut bodies = vec![Body::new(Vec2::zero(), Vec2::zero(), 1.0, 1.0, 1.0, Species::LithiumIon)];
+        let foils: Vec<Foil> = Vec::new();
+
+        // First update at t=0 to set baseline
+        plotting.update_plots(&bodies, &foils, 0.0);
+
+        // Ion becomes metal
+        bodies[0].species = Species::LithiumMetal;
+
+        // Second update after 1s
+        plotting.update_plots(&bodies, &foils, 1.0);
+        let window = plotting.windows.get(&window_id).unwrap();
+        assert_eq!(window.data.y_data.len(), 1);
+        assert!((window.data.y_data[0] - 1.0).abs() < 1e-6);
+    }
+}
+


### PR DESCRIPTION
## Summary
- support a new `DendriteFormationRate` quantity for plot windows
- track previous metal count in each `PlotWindow`
- update plotting GUI for the new rate type
- document dendrite rate plotting in README and PLOTTING_FEATURES
- add a unit test for dendrite formation rate calculation

## Testing
- `cargo test --quiet` *(fails: failed to fetch dependency)*

------
https://chatgpt.com/codex/tasks/task_b_686c203204188332a601af3696e78b59