### PR TITLE
Remove legacy current slider

### DIFF
--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -551,17 +551,19 @@ impl super::Renderer {
         for id in &self.selected_foil_ids {
             if let Some(foil) = self.foils.iter().find(|f| f.id == *id) {
                 // Calculate effective current using the same logic as simulation
-                let effective_current = if foil.switch_hz > 0.0 {
-                    // DC component plus AC component (square wave)
-                    let ac_component = if (time * foil.switch_hz) % 1.0 < 0.5 { 
-                        foil.ac_current 
-                    } else { 
-                        -foil.ac_current 
-                    };
-                    foil.dc_current + ac_component
-                } else {
-                    // Use legacy current field when no switching
-                    foil.current
+                let effective_current = {
+                    // DC component is always active
+                    let mut current = foil.dc_current;
+                    // Add AC component only if frequency is set
+                    if foil.switch_hz > 0.0 {
+                        let ac_component = if (time * foil.switch_hz) % 1.0 < 0.5 { 
+                            foil.ac_current 
+                        } else { 
+                            -foil.ac_current 
+                        };
+                        current += ac_component;
+                    }
+                    current
                 };
                 
                 // Normalize to 0-1 range for wave display (show activity when current != 0)

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -397,22 +397,6 @@ impl super::Renderer {
                         foils.iter().find(|f| f.body_ids.contains(&selected_id)).cloned()
                     };
                     if let Some(foil) = maybe_foil {
-                        ui.separator();
-                        egui::CollapsingHeader::new("Foil Current").default_open(true).show(ui, |ui| {
-                            // Legacy current control (for backwards compatibility when no switching)
-                            let mut current = foil.current;
-                            ui.horizontal(|ui| {
-                                ui.label("Current (legacy):");
-                                if ui.button("-").clicked() { current -= 1.0; }
-                                if ui.button("+").clicked() { current += 1.0; }
-                                if ui.button("0").clicked() { current = 0.0; }
-                                ui.add(egui::Slider::new(&mut current, -500.0..=500.00).step_by(0.1));
-                            });
-                            if (current - foil.current).abs() > f32::EPSILON {
-                                SIM_COMMAND_SENDER.lock().as_ref().unwrap().send(
-                                    SimCommand::SetFoilCurrent { foil_id: selected_id, current }
-                                ).unwrap();
-                            }
 
                             ui.separator();
                             ui.label("DC + AC Current Components:");
@@ -500,7 +484,6 @@ impl super::Renderer {
                                     }
                                 }
                             });
-                        });
                     }
                 }
 

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -464,18 +464,20 @@ impl super::Renderer {
                                         let mut points_vec: Vec<[f64; 2]> = Vec::with_capacity(steps + 1);
                                         for i in 0..=steps {
                                             let t = i as f32 * dt;
-                                            let effective_current = if f.switch_hz > 0.0 {
-                                                // DC + AC components - use same phase calculation as simulation
-                                                let plot_time = current_time + t;
-                                                let ac_component = if (plot_time * f.switch_hz) % 1.0 < 0.5 { 
-                                                    f.ac_current 
-                                                } else { 
-                                                    -f.ac_current 
-                                                };
-                                                f.dc_current + ac_component
-                                            } else {
-                                                // Use legacy current field when no switching
-                                                f.current
+                                            let effective_current = {
+                                                // DC component is always active
+                                                let mut current = f.dc_current;
+                                                // Add AC component only if frequency is set
+                                                if f.switch_hz > 0.0 {
+                                                    let plot_time = current_time + t;
+                                                    let ac_component = if (plot_time * f.switch_hz) % 1.0 < 0.5 { 
+                                                        f.ac_current 
+                                                    } else { 
+                                                        -f.ac_current 
+                                                    };
+                                                    current += ac_component;
+                                                }
+                                                current
                                             };
                                             points_vec.push([t as f64, effective_current as f64]);
                                         }


### PR DESCRIPTION
## Summary
- remove obsolete 'Current (legacy)' controls from GUI

## Testing
- `cargo check --locked --offline` *(fails: unable to load git dependency offline)*

------
https://chatgpt.com/codex/tasks/task_b_686ee72218ec83329bc50460f3ef94e3