### PR TITLE
Expand LJ forces to all species

### DIFF
--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -159,4 +159,20 @@ impl Species {
     pub fn damping(&self) -> f32 {
         self.props().damping
     }
+
+    pub fn lj_epsilon(&self) -> f32 {
+        self.props().lj_epsilon
+    }
+
+    pub fn lj_sigma(&self) -> f32 {
+        self.props().lj_sigma
+    }
+
+    pub fn lj_cutoff(&self) -> f32 {
+        self.props().lj_cutoff
+    }
+
+    pub fn lj_enabled(&self) -> bool {
+        self.props().lj_enabled
+    }
 }

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -3,7 +3,6 @@
 //! Provides routines for computing electric (Coulomb) forces and Lennard-Jones (LJ) forces between bodies.
 //! Used by the main simulation loop to update accelerations and fields.
 
-use crate::body::Species;
 use crate::config;
 use crate::simulation::Simulation;
 use crate::profile_scope;
@@ -37,51 +36,44 @@ pub fn attract(sim: &mut Simulation) {
 /// - Forces are clamped to avoid instability.
 pub fn apply_lj_forces(sim: &mut Simulation) {
     profile_scope!("forces_lj");
-    let sigma = sim.config.lj_force_sigma;
-    let epsilon = sim.config.lj_force_epsilon;
-    let cutoff = sim.config.lj_force_cutoff * sigma;
+    let max_cutoff = crate::species::max_lj_cutoff();
     let use_cell = sim.use_cell_list();
     if use_cell {
-        sim.cell_list.cell_size = cutoff;
+        sim.cell_list.cell_size = max_cutoff;
         sim.cell_list.rebuild(&sim.bodies);
     } else {
         sim.quadtree.build(&mut sim.bodies);
     }
 
     for i in 0..sim.bodies.len() {
-        // Only apply LJ to LithiumMetal or FoilMetal
-        if !(sim.bodies[i].species == Species::LithiumMetal || sim.bodies[i].species == Species::FoilMetal) {
-            continue;
-        }
+        if !sim.bodies[i].species.lj_enabled() { continue; }
         let neighbors = if use_cell {
-            sim.cell_list.find_neighbors_within(&sim.bodies, i, cutoff)
+            sim.cell_list.find_neighbors_within(&sim.bodies, i, max_cutoff)
         } else {
-            sim.quadtree.find_neighbors_within(&sim.bodies, i, cutoff)
+            sim.quadtree.find_neighbors_within(&sim.bodies, i, max_cutoff)
         };
         for &j in &neighbors {
             if j <= i { continue; }
+            if !sim.bodies[j].species.lj_enabled() { continue; }
             let (a, b) = {
                 let (left, right) = sim.bodies.split_at_mut(j);
                 (&mut left[i], &mut right[0])
             };
-            // Apply LJ between LithiumMetal and/or FoilMetal
-            if (a.species == Species::LithiumMetal || a.species == Species::FoilMetal) &&
-               (b.species == Species::LithiumMetal || b.species == Species::FoilMetal) {
-                let r_vec = b.pos - a.pos;
-                let r = r_vec.mag();
-                if r < cutoff && r > 1e-6 {
-                    let sr6 = (sigma / r).powi(6);
-                    let max_lj_force = config::COLLISION_PASSES as f32 * config::LJ_FORCE_MAX;
-                    let unclamped_force_mag = 24.0 * epsilon * (2.0 * sr6 * sr6 - sr6) / r;
-                    let force_mag = unclamped_force_mag.clamp(-max_lj_force, max_lj_force);
-                    let force = force_mag * r_vec.normalized();
-                    //println!("LJ DEBUG: r={:.3}, sr6={:.3}, force_mag={:.3}, force=({:.3},{:.3})", r, sr6, force_mag, force.x, force.y);
-                    
-                    // Update acceleration (SWAPPED SIGNS)
-                    a.acc -= force / a.mass;
-                    b.acc += force / b.mass;
+            let sigma = (a.species.lj_sigma() + b.species.lj_sigma()) * 0.5;
+            let epsilon = (a.species.lj_epsilon() * b.species.lj_epsilon()).sqrt();
+            let cutoff =
+                0.5 * (a.species.lj_cutoff() * a.species.lj_sigma() + b.species.lj_cutoff() * b.species.lj_sigma());
+            let r_vec = b.pos - a.pos;
+            let r = r_vec.mag();
+            if r < cutoff && r > 1e-6 {
+                let sr6 = (sigma / r).powi(6);
+                let max_lj_force = config::COLLISION_PASSES as f32 * config::LJ_FORCE_MAX;
+                let unclamped_force_mag = 24.0 * epsilon * (2.0 * sr6 * sr6 - sr6) / r;
+                let force_mag = unclamped_force_mag.clamp(-max_lj_force, max_lj_force);
+                let force = force_mag * r_vec.normalized();
 
-                }
+                a.acc -= force / a.mass;
+                b.acc += force / b.mass;
             }
         }
     }

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -39,7 +39,7 @@ impl Simulation {
         // Start with no bodies; scenario setup is now done via SimCommand AddCircle/AddBody
         let bodies = Vec::new();
         let quadtree = Quadtree::new(theta, epsilon, leaf_capacity, thread_capacity);
-        let cell_size = config::LJ_FORCE_CUTOFF * config::LJ_FORCE_SIGMA;
+        let cell_size = crate::species::max_lj_cutoff();
         let cell_list = CellList::new(bounds, cell_size);
         let rewound_flags = vec![];
         let sim = Self {
@@ -345,7 +345,7 @@ impl Simulation {
     pub fn update_surrounded_flags(&mut self) {
         if self.bodies.is_empty() { return; }
         let use_cell = self.use_cell_list();
-        let neighbor_radius = self.config.lj_force_cutoff * self.config.lj_force_sigma;
+        let neighbor_radius = crate::species::max_lj_cutoff();
         if use_cell {
             self.cell_list.cell_size = neighbor_radius;
             self.cell_list.rebuild(&self.bodies);

--- a/src/species.rs
+++ b/src/species.rs
@@ -8,15 +8,72 @@ pub struct SpeciesProps {
     pub mass: f32,
     pub radius: f32,
     pub damping: f32,
+    pub lj_epsilon: f32,
+    pub lj_sigma: f32,
+    pub lj_cutoff: f32,
+    pub lj_enabled: bool,
 }
 
 pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(|| {
     use Species::*;
     let mut m = HashMap::new();
-    m.insert(LithiumIon, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
-    m.insert(LithiumMetal, SpeciesProps { mass: 1.0, radius: 1.0, damping: 1.0 });
-    m.insert(FoilMetal, SpeciesProps { mass: 1e6, radius: 1.0, damping: 1.0 });
-    m.insert(ElectrolyteAnion, SpeciesProps { mass: 40.0, radius: 1.5, damping: 1.0 });
+    m.insert(
+        LithiumIon,
+        SpeciesProps {
+            mass: 1.0,
+            radius: 1.0,
+            damping: 1.0,
+            lj_epsilon: 0.0,
+            lj_sigma: crate::config::LJ_FORCE_SIGMA,
+            lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            lj_enabled: false,
+        },
+    );
+    m.insert(
+        LithiumMetal,
+        SpeciesProps {
+            mass: 1.0,
+            radius: 1.0,
+            damping: 1.0,
+            lj_epsilon: crate::config::LJ_FORCE_EPSILON,
+            lj_sigma: crate::config::LJ_FORCE_SIGMA,
+            lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            lj_enabled: true,
+        },
+    );
+    m.insert(
+        FoilMetal,
+        SpeciesProps {
+            mass: 1e6,
+            radius: 1.0,
+            damping: 1.0,
+            lj_epsilon: crate::config::LJ_FORCE_EPSILON,
+            lj_sigma: crate::config::LJ_FORCE_SIGMA,
+            lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            lj_enabled: true,
+        },
+    );
+    m.insert(
+        ElectrolyteAnion,
+        SpeciesProps {
+            mass: 40.0,
+            radius: 1.5,
+            damping: 1.0,
+            lj_epsilon: 0.0,
+            lj_sigma: crate::config::LJ_FORCE_SIGMA,
+            lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            lj_enabled: false,
+        },
+    );
     m
 });
+
+/// Maximum LJ interaction range across all species.
+pub fn max_lj_cutoff() -> f32 {
+    SPECIES_PROPERTIES
+        .values()
+        .filter(|p| p.lj_enabled)
+        .map(|p| p.lj_cutoff * p.lj_sigma)
+        .fold(0.0_f32, f32::max)
+}
 


### PR DESCRIPTION
## Summary
- support Lennard-Jones properties per species
- compute max LJ cutoff from species data
- update cell list construction and neighbor search
- calculate pairwise LJ parameters for every enabled species pair
- remove metal-only checks

## Testing
- `cargo check` *(fails: could not fetch `quarkstrom` dependency)*
- `cargo fmt` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686ee89a3e088332b543eb2ba58721f5