### PR TITLE
Fix save state directory creation

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -35,8 +35,13 @@ impl SimulationState {
 }
 
 pub fn save_state<P: AsRef<Path>>(path: P, sim: &Simulation) -> std::io::Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let state = SimulationState::from_simulation(sim);
-    let json = serde_json::to_string_pretty(&state).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let json = serde_json::to_string_pretty(&state)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     std::fs::write(path, json)
 }
 

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -453,6 +453,8 @@ impl super::Renderer {
                         use std::fs;
                         use std::path::PathBuf;
                         let saved_state_dir = PathBuf::from("saved_state");
+                        // Ensure directory exists
+                        let _ = fs::create_dir_all(&saved_state_dir);
                         // List all .json files in saved_state
                         let mut state_files: Vec<String> = fs::read_dir(&saved_state_dir)
                             .map(|rd| rd.filter_map(|e| e.ok())


### PR DESCRIPTION
## Summary
- ensure directory exists before writing simulation state
- initialize `saved_state` folder in the GUI

## Testing
- `cargo check --quiet` *(fails: failed to fetch `quarkstrom` due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6876f776028c8332b55a7747679aed84