### PR TITLE
Refactor renderer settings GUI

### DIFF
--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -247,7 +247,7 @@ impl super::Renderer {
                         });
                         ui.label(format!("Effective LJ range: {:.2}", current_props.lj_cutoff * current_props.lj_sigma));
                     }
-                }
+                });
                     SettingsTab::ButlerVolmer => {
                     ui.checkbox(&mut self.sim_config.use_butler_volmer, "Use Butler-Volmer");
                     ui.add(
@@ -652,7 +652,7 @@ impl super::Renderer {
                                 }
                             });
                     }
-                }
+                });
                     SettingsTab::Links => {
                         egui::CollapsingHeader::new("Foil Links").default_open(true).show(ui, |ui| {
                     if self.selected_foil_ids.len() == 2 {
@@ -675,7 +675,7 @@ impl super::Renderer {
                             });
                         }
                     }
-                }
+                });
                     SettingsTab::Debug => {
                         egui::CollapsingHeader::new("Debug/Diagnostics").default_open(true).show(ui, |ui| {
                             ui.checkbox(&mut self.sim_config.show_lj_vs_coulomb_ratio, "Show LJ/Coulomb Force Ratio");

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -20,6 +20,27 @@ pub enum DeleteOption {
     ElectrolyteAnion,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SettingsTab {
+    Field,
+    Display,
+    Simulation,
+    Overlays,
+    Species,
+    ButlerVolmer,
+    Scenario,
+    Foil,
+    Links,
+    Debug,
+    Plotting,
+}
+
+impl Default for SettingsTab {
+    fn default() -> Self {
+        Self::Field
+    }
+}
+
 pub struct Renderer {
     pos: Vec2,
     scale: f32,
@@ -39,6 +60,7 @@ pub struct Renderer {
     //foils: Vec<crate::body::foil::Foil>,
     selected_foil_ids: Vec<u64>,
     selected_particle_ids: Vec<u64>,
+    active_tab: SettingsTab,
     sim_config: SimConfig,
     /// Local copy of the simulation frame for time-based visualizations
     frame: usize,
@@ -102,6 +124,7 @@ impl quarkstrom::Renderer for Renderer {
             //foils: Vec::new(),
             selected_foil_ids: Vec::new(),
             selected_particle_ids: Vec::new(),
+            active_tab: SettingsTab::Field,
             sim_config: crate::config::LJ_CONFIG.lock().clone(),
             frame: 0,
             foil_wave_history: HashMap::new(),


### PR DESCRIPTION
## Summary
- introduce `SettingsTab` to group GUI sections
- track the active tab on `Renderer`
- show GUI with tab bar navigation

## Testing
- `cargo check` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6876fddbbcdc8332af649f12fdd30c7c