### PR TITLE
Add screen capture controls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ crossbeam = "0.8.4"
 broccoli-rayon = "0.4.0"
 rand = "0.9.1"
 smallvec = { version = "1.10.0", features = ["serde"] }
+image = "0.24"
 
 [features]
 profiling = []

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This repository contains a modular, parallelized particle simulation for large-s
 - **State Management**:
   - Save and load simulation states for reproducible experiments.
   - Pre-configured scenarios for quick setup.
-- **Configurable Physics**:  
+- **Screen Capture**: Record the simulation view to PNG images at regular intervals.
+- **Configurable Physics**:
   - Adjustable Lennard-Jones parameters per species, electron hopping rates, and Butler-Volmer coefficients. Each species can enable or disable LJ forces to model either "metal-like" cohesion or "liquid-like" behavior.
   - Domain bounds, timestep settings, and force cutoffs can be modified at runtime.
 
@@ -74,6 +75,7 @@ This repository contains a modular, parallelized particle simulation for large-s
 - **Scenario Controls**: Quick setup with predefined particle arrangements
 - **State Management**: Save and load simulation configurations
 - **Manual Stepping**: Advance simulation one timestep at a time for debugging
+- **Screen Capture**: Periodically save the visible region to PNG files
 
 ---
 
@@ -127,6 +129,10 @@ The simulation includes a comprehensive plotting system for real-time data analy
 3. Choose quantity to analyze (charge, velocity, species count, etc.)
 4. Configure sampling mode and update frequency
 5. Export data for external analysis when needed
+6. Use **Screen Capture** to record images:
+   - Open the "Screen Capture" section in the GUI
+   - Click **Start Recording** and drag a box over the area to capture
+   - PNG files will be written to the selected directory at the chosen interval
 
 ---
 

--- a/src/renderer/draw.rs
+++ b/src/renderer/draw.rs
@@ -277,6 +277,12 @@ impl super::Renderer {
         if !self.selected_foil_ids.is_empty() {
             self.draw_foil_square_waves(ctx);
         }
+
+        if let Some((a, b)) = self.record_rect {
+            let min = Vec2::new(a.x.min(b.x), a.y.min(b.y));
+            let max = Vec2::new(a.x.max(b.x), a.y.max(b.y));
+            ctx.draw_rect(min, max, [255, 0, 0, 255]);
+        }
     }
 }
 

--- a/src/renderer/gui.rs
+++ b/src/renderer/gui.rs
@@ -688,6 +688,28 @@ impl super::Renderer {
                     ui.checkbox(&mut self.show_electron_deficiency, "Show Electron Deficiency/Excess");
                 });
 
+                // --- Screen Capture ---
+                ui.separator();
+                egui::CollapsingHeader::new("Screen Capture").default_open(false).show(ui, |ui| {
+                    if self.recording {
+                        if ui.button("Stop Recording").clicked() {
+                            self.recording = false;
+                        }
+                    } else {
+                        if ui.button("Start Recording").clicked() {
+                            self.start_recording();
+                        }
+                    }
+                    ui.add(egui::DragValue::new(&mut self.capture_interval).prefix("Interval ").speed(0.1));
+                    let mut dir = self.output_dir.to_string_lossy().to_string();
+                    if ui.text_edit_singleline(&mut dir).lost_focus() {
+                        self.output_dir = std::path::PathBuf::from(dir.clone());
+                    }
+                    if ui.button("Create Dir").clicked() {
+                        let _ = std::fs::create_dir_all(&self.output_dir);
+                    }
+                });
+
                 // --- Plotting & Analysis ---
                 ui.separator();
                 crate::plotting::gui::show_plotting_controls(

--- a/src/renderer/input.rs
+++ b/src/renderer/input.rs
@@ -75,6 +75,24 @@ impl super::Renderer {
             mouse * self.scale + self.pos
         };
 
+        if self.recording && self.record_rect.is_none() {
+            if input.mouse_pressed(1) {
+                let m = world_mouse();
+                self.record_rect = Some((m, m));
+            } else if input.mouse_held(1) {
+                if let Some(rect) = &mut self.record_rect {
+                    rect.1 = world_mouse();
+                }
+            } else if input.mouse_released(1) {
+                if let Some(rect) = &mut self.record_rect {
+                    rect.1 = world_mouse();
+                }
+            }
+            if input.mouse_held(1) || input.mouse_pressed(1) {
+                return;
+            }
+        }
+
         if input.mouse_pressed(1) {
             if self.spawn_body.is_none() {
                 // If shift is held, select a particle

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -10,6 +10,10 @@ use crate::plotting::{PlottingSystem, PlotType, Quantity, SamplingMode};
 use ultraviolet::Vec2;
 use quarkstrom::winit_input_helper::WinitInputHelper;
 use std::collections::HashMap;
+use std::path::PathBuf;
+use image;
+use wgpu;
+use pollster;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum DeleteOption {
@@ -79,6 +83,12 @@ pub struct Renderer {
     pub selected_lj_species: Species,
     // Delete species selection
     pub selected_delete_option: DeleteOption,
+    // Screen capture fields
+    recording: bool,
+    record_rect: Option<(Vec2, Vec2)>,
+    capture_interval: f32,
+    next_capture_time: f32,
+    output_dir: std::path::PathBuf,
 }
 
 impl quarkstrom::Renderer for Renderer {
@@ -135,6 +145,11 @@ impl quarkstrom::Renderer for Renderer {
             domain_height: 300.0,
             selected_lj_species: Species::LithiumMetal, // Default to LithiumMetal for LJ editing
             selected_delete_option: DeleteOption::AllSpecies, // Default to All Species
+            recording: false,
+            record_rect: None,
+            capture_interval: 0.1,
+            next_capture_time: 0.0,
+            output_dir: std::path::PathBuf::from("captures"),
         }
     }
 
@@ -151,6 +166,110 @@ impl quarkstrom::Renderer for Renderer {
         self.show_gui(ctx);
         // After GUI update, write changes to global config
         *crate::config::LJ_CONFIG.lock() = self.sim_config.clone();
+    }
+
+    fn post_render(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, texture: &wgpu::Texture, width: u32, height: u32) {
+        self.capture_frame(device, queue, texture, width, height);
+    }
+}
+
+impl Renderer {
+    pub fn start_recording(&mut self) {
+        self.recording = true;
+        self.record_rect = None;
+        self.next_capture_time = *crate::renderer::state::SIM_TIME.lock() + self.capture_interval;
+    }
+
+    fn save_rgba_png(&self, data: &[u8], width: u32, height: u32, sim_time: f32) {
+        std::fs::create_dir_all(&self.output_dir).ok();
+        let fname = format!("frame_{:.2}.png", sim_time).replace('.', "_");
+        let path = self.output_dir.join(fname);
+        let img = image::RgbaImage::from_raw(width, height, data.to_vec()).unwrap();
+        img.save(path).unwrap();
+    }
+
+    fn world_to_pixel(&self, world: Vec2, width: u32, height: u32) -> (u32, u32) {
+        let width_pixels = width as f32 * self.scale_factor;
+        let height_pixels = height as f32 * self.scale_factor;
+        let rel = (world - self.pos) / self.scale;
+        let mx = (rel.x + width_pixels / height_pixels) * height_pixels / 2.0;
+        let my = (1.0 - rel.y) * height_pixels / 2.0;
+        let x = mx.clamp(0.0, width_pixels - 1.0).round() as u32;
+        let y = my.clamp(0.0, height_pixels - 1.0).round() as u32;
+        (x, y)
+    }
+
+    pub fn capture_frame(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, texture: &wgpu::Texture, width: u32, height: u32) {
+        let sim_time = *crate::renderer::state::SIM_TIME.lock();
+        if !self.recording || sim_time < self.next_capture_time {
+            return;
+        }
+        self.next_capture_time += self.capture_interval;
+
+        let buffer_size = (width * height * 4) as wgpu::BufferAddress;
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("capture_buffer"),
+            size: buffer_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("capture_encoder") });
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer: &buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(std::num::NonZeroU32::new(4 * width).unwrap()),
+                    rows_per_image: Some(std::num::NonZeroU32::new(height).unwrap()),
+                },
+            },
+            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        device.poll(wgpu::Maintain::Wait);
+        let slice = buffer.slice(..);
+        pollster::block_on(slice.map_async(wgpu::MapMode::Read)).unwrap();
+        let data = slice.get_mapped_range().to_vec();
+        buffer.unmap();
+
+        let mut rgba = vec![0u8; data.len()];
+        for i in 0..(width * height) as usize {
+            rgba[i * 4] = data[i * 4 + 2];
+            rgba[i * 4 + 1] = data[i * 4 + 1];
+            rgba[i * 4 + 2] = data[i * 4];
+            rgba[i * 4 + 3] = data[i * 4 + 3];
+        }
+
+        let (mut final_w, mut final_h) = (width, height);
+        let mut final_data = rgba;
+        if let Some((a, b)) = self.record_rect {
+            let (x0, y0) = self.world_to_pixel(a, width, height);
+            let (x1, y1) = self.world_to_pixel(b, width, height);
+            let min_x = x0.min(x1);
+            let min_y = y0.min(y1);
+            let max_x = x0.max(x1);
+            let max_y = y0.max(y1);
+            final_w = max_x - min_x;
+            final_h = max_y - min_y;
+            let mut cropped = vec![0u8; (final_w * final_h * 4) as usize];
+            for y in 0..final_h {
+                let src = ((min_y + y) * width + min_x) as usize * 4;
+                let dst = (y * final_w) as usize * 4;
+                let len = (final_w * 4) as usize;
+                cropped[dst..dst + len].copy_from_slice(&final_data[src..src + len]);
+            }
+            final_data = cropped;
+        }
+
+        self.save_rgba_png(&final_data, final_w, final_h, sim_time);
     }
 }
 

--- a/src/renderer/tests.rs
+++ b/src/renderer/tests.rs
@@ -41,4 +41,25 @@ mod tests {
         let last_current = history[history.len() - 1].1;
         assert!((first_current - last_current).abs() < 0.001, "Current values should be consistent for constant current");
     }
+
+    #[test]
+    fn start_recording_schedules_next_capture() {
+        let mut r = Renderer::new();
+        r.capture_interval = 0.5;
+        *crate::renderer::state::SIM_TIME.lock() = 1.0;
+        r.start_recording();
+        assert!((r.next_capture_time - 1.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn save_image_creates_file() {
+        let mut r = Renderer::new();
+        let dir = std::env::temp_dir().join("psim_test_out");
+        std::fs::create_dir_all(&dir).unwrap();
+        let data = vec![255u8, 0, 0, 255];
+        r.output_dir = dir.clone();
+        r.save_rgba_png(&data, 1, 1, 0.0);
+        assert!(dir.join("frame_0_00.png").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary
- add `image` as dependency
- extend `Renderer` with screen capture state
- draw selection rectangle and save captured frames
- expose recording controls via GUI
- update input handling for drag-selection
- document screen capture feature
- unit tests for scheduling and file output

## Testing
- `cargo test --quiet` *(fails: network fetch)*

------
https://chatgpt.com/codex/tasks/task_b_6877089fccf48332b2a2c62724ad41f3