### PR TITLE
Add capture region ratio for screen captures

### DIFF
--- a/src/renderer/draw/mod.rs
+++ b/src/renderer/draw/mod.rs
@@ -294,7 +294,12 @@ impl super::Renderer {
         }
 
         // Draw the saved capture region if one exists
-        if let Some((world_start, world_end)) = self.capture_region {
+        if let Some((ratio_start, ratio_end)) = self.capture_region_ratio {
+            let start_screen = Vec2::new(ratio_start.x * width as f32, ratio_start.y * height as f32);
+            let end_screen = Vec2::new(ratio_end.x * width as f32, ratio_end.y * height as f32);
+            let world_start = self.screen_to_world(start_screen, width, height);
+            let world_end = self.screen_to_world(end_screen, width, height);
+
             let min_x = world_start.x.min(world_end.x);
             let max_x = world_start.x.max(world_end.x);
             let min_y = world_start.y.min(world_end.y);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -114,6 +114,7 @@ pub struct Renderer {
     pub selection_start: Option<Vec2>,  // for drag selection
     pub selection_end: Option<Vec2>,
     pub capture_region: Option<(Vec2, Vec2)>,  // (top_left, bottom_right) in world space
+    pub capture_region_ratio: Option<(Vec2, Vec2)>,
     pub is_selecting_region: bool,
     pub capture_counter: usize,
     pub show_capture_window: bool,
@@ -186,6 +187,7 @@ impl quarkstrom::Renderer for Renderer {
             selection_start: None,
             selection_end: None,
             capture_region: None,
+            capture_region_ratio: None,
             is_selecting_region: false,
             capture_counter: 0,
             show_capture_window: false,

--- a/src/renderer/screen_capture_tests.rs
+++ b/src/renderer/screen_capture_tests.rs
@@ -52,7 +52,7 @@ mod tests {
         renderer.update_region_selection(end);
         assert_eq!(renderer.selection_end, Some(end));
         
-        renderer.finish_region_selection();
+        renderer.finish_region_selection(800, 600);
         assert!(!renderer.is_selecting_region);
         assert_eq!(renderer.capture_region, Some((start, end)));
         assert!(renderer.selection_start.is_none());


### PR DESCRIPTION
## Summary
- track capture regions as fractions of window size
- crop using these ratios in screen capture code
- recalc region after resize and draw overlay from ratios
- update tests for new API

## Testing
- `cargo test --quiet` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_b_687950dde4888332b309f8c8c7dacfef