### PR TITLE
Fix finish_region_selection test usage

### DIFF
--- a/src/renderer/screen_capture.rs
+++ b/src/renderer/screen_capture.rs
@@ -537,7 +537,7 @@ mod tests {
         renderer.update_region_selection(end);
         assert_eq!(renderer.selection_end, Some(end));
         
-        renderer.finish_region_selection();
+        renderer.finish_region_selection(800, 600);
         assert!(!renderer.is_selecting_region);
         assert_eq!(renderer.capture_region, Some((start, end)));
         assert!(renderer.selection_start.is_none());

--- a/src/renderer/screen_capture_tests.rs
+++ b/src/renderer/screen_capture_tests.rs
@@ -52,7 +52,7 @@ mod tests {
         renderer.update_region_selection(end);
         assert_eq!(renderer.selection_end, Some(end));
         
-        renderer.finish_region_selection();
+        renderer.finish_region_selection(800, 600);
         assert!(!renderer.is_selecting_region);
         assert_eq!(renderer.capture_region, Some((start, end)));
         assert!(renderer.selection_start.is_none());


### PR DESCRIPTION
## Summary
- update tests to pass window dimensions to `finish_region_selection`
- adjust duplicate tests in `screen_capture.rs` accordingly

## Testing
- `cargo test --no-run --offline` *(fails: unable to fetch `quarkstrom` dependency offline)*

------
https://chatgpt.com/codex/tasks/task_b_687950de4fec8332b63838953bf53504