### PR TITLE
Make electron spring constant species-specific

### DIFF
--- a/src/body/electron.rs
+++ b/src/body/electron.rs
@@ -22,7 +22,7 @@ impl Body {
         background_field: Vec2,
         dt: f32,
     ) {
-        let k = config::ELECTRON_SPRING_K;
+        let k = config::electron_spring_k(self.species);
         for e in &mut self.electrons {
             let electron_pos = self.pos + e.rel_pos;
             let local_field =

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,22 @@
 // Electron Parameters
 // ====================
 pub const ELECTRON_SPRING_K: f32 = 0.05;                // Spring constant for electron drift
+pub const ELECTRON_SPRING_K_METAL: f32 = ELECTRON_SPRING_K; // Metal-specific spring constant
+pub const ELECTRON_SPRING_K_EC: f32 = ELECTRON_SPRING_K;    // EC-specific spring constant
+pub const ELECTRON_SPRING_K_DMC: f32 = ELECTRON_SPRING_K;   // DMC-specific spring constant
+
+use crate::body::Species;
+
+/// Get the electron spring constant for a given species
+pub fn electron_spring_k(species: Species) -> f32 {
+    use Species::*;
+    match species {
+        LithiumMetal | FoilMetal => ELECTRON_SPRING_K_METAL,
+        EC => ELECTRON_SPRING_K_EC,
+        DMC => ELECTRON_SPRING_K_DMC,
+        _ => ELECTRON_SPRING_K,
+    }
+}
 pub const ELECTRON_DRIFT_RADIUS_FACTOR: f32 = 1.2;      // Max drift radius as a factor of body radius
 pub const ELECTRON_MAX_SPEED_FACTOR: f32 = 1.2;         // Max electron speed as a factor of body radius per dt
 pub const HOP_RADIUS_FACTOR: f32 = 2.1;                      // Hopping radius as a factor of body radius

--- a/src/renderer/screen_capture.rs
+++ b/src/renderer/screen_capture.rs
@@ -357,12 +357,14 @@ impl Renderer {
         Vec2::new(world_x, world_y)
     }
 
+    #[allow(dead_code)]
     pub fn start_region_selection(&mut self, start_pos: Vec2) {
         self.is_selecting_region = true;
         self.selection_start = Some(start_pos);
         self.selection_end = None;
     }
 
+    #[allow(dead_code)]
     pub fn update_region_selection(&mut self, end_pos: Vec2) {
         self.selection_end = Some(end_pos);
     }


### PR DESCRIPTION
## Summary
- allow lookup of electron spring constant per species
- use new lookup when updating electrons

## Testing
- `cargo test --quiet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a8b419b7883329f78a2bf502c7082