### PR TITLE
Add foil electron fraction diagnostic

### DIFF
--- a/src/diagnostics/foil_electron_fraction.rs
+++ b/src/diagnostics/foil_electron_fraction.rs
@@ -1,0 +1,65 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::body::{Body, Species, foil::Foil};
+
+/// Diagnostic calculating the ratio of actual electrons to neutral electrons
+/// for each foil and connected metal cluster.
+#[derive(Default)]
+pub struct FoilElectronFractionDiagnostic {
+    pub fractions: HashMap<u64, f32>,
+}
+
+impl FoilElectronFractionDiagnostic {
+    pub fn new() -> Self {
+        Self { fractions: HashMap::new() }
+    }
+
+    /// Recompute electron fractions for all foils.
+    pub fn calculate(&mut self, bodies: &[Body], foils: &[Foil]) {
+        self.fractions.clear();
+        let id_to_index: HashMap<u64, usize> = bodies
+            .iter()
+            .enumerate()
+            .map(|(i, b)| (b.id, i))
+            .collect();
+
+        for foil in foils {
+            let mut queue = VecDeque::new();
+            let mut visited: HashSet<usize> = HashSet::new();
+            let mut total_electrons = 0usize;
+            let mut total_neutral = 0usize;
+
+            for id in &foil.body_ids {
+                if let Some(&idx) = id_to_index.get(id) {
+                    queue.push_back(idx);
+                    visited.insert(idx);
+                }
+            }
+
+            while let Some(idx) = queue.pop_front() {
+                let body = &bodies[idx];
+                total_electrons += body.electrons.len();
+                total_neutral += body.neutral_electron_count();
+                for (j, other) in bodies.iter().enumerate() {
+                    if visited.contains(&j) {
+                        continue;
+                    }
+                    if !matches!(other.species, Species::LithiumMetal | Species::FoilMetal) {
+                        continue;
+                    }
+                    let threshold = (body.radius + other.radius) * 1.1;
+                    if (body.pos - other.pos).mag() <= threshold {
+                        visited.insert(j);
+                        queue.push_back(j);
+                    }
+                }
+            }
+
+            if total_neutral > 0 {
+                self.fractions
+                    .insert(foil.id, total_electrons as f32 / total_neutral as f32);
+            }
+        }
+    }
+}
+

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -2,5 +2,7 @@
 // Module for diagnostics-related calculations and GUI integration
 
 pub mod transference_number;
+pub mod foil_electron_fraction;
 
 pub use transference_number::*;
+pub use foil_electron_fraction::*;

--- a/src/renderer/draw/mod.rs
+++ b/src/renderer/draw/mod.rs
@@ -38,7 +38,13 @@ impl super::Renderer {
                     diagnostic.calculate(&self.bodies);
                 }
                 if let Some(ref mut diag) = self.foil_electron_fraction_diagnostic {
-                    diag.calculate(&self.bodies, &self.foils);
+                    // Create a temporary quadtree for diagnostic calculation
+                    let mut temp_quadtree = crate::quadtree::Quadtree::new(1.0, 2.0, 1, 1024);
+                    temp_quadtree.nodes = self.quadtree.clone();
+                    
+                    // Use time-throttled calculation to avoid performance issues
+                    let current_time = *crate::renderer::state::SIM_TIME.lock();
+                    diag.calculate_if_needed(&self.bodies, &self.foils, &temp_quadtree, current_time, 1.0);
                 }
             }
             if let Some(body) = self.confirmed_bodies.take() {

--- a/src/renderer/draw/mod.rs
+++ b/src/renderer/draw/mod.rs
@@ -37,6 +37,9 @@ impl super::Renderer {
                 if let Some(ref mut diagnostic) = self.transference_number_diagnostic {
                     diagnostic.calculate(&self.bodies);
                 }
+                if let Some(ref mut diag) = self.foil_electron_fraction_diagnostic {
+                    diag.calculate(&self.bodies, &self.foils);
+                }
             }
             if let Some(body) = self.confirmed_bodies.take() {
                 self.bodies.push(body.clone());

--- a/src/renderer/gui/diagnostics_tab.rs
+++ b/src/renderer/gui/diagnostics_tab.rs
@@ -64,7 +64,17 @@ impl super::super::Renderer {
         // Foil electron fraction diagnostic
         ui.group(|ui| {
             ui.label("🔋 Foil Electron Ratio");
-            if let Some(diag) = &self.foil_electron_fraction_diagnostic {
+            
+            // Update diagnostic periodically using quadtree for efficiency
+            if let Some(diag) = &mut self.foil_electron_fraction_diagnostic {
+                // Reconstruct quadtree from current node data for diagnostic calculation
+                let mut temp_quadtree = crate::quadtree::Quadtree::new(1.0, 2.0, 1, 1024);
+                temp_quadtree.nodes = self.quadtree.clone();
+                
+                // Only recalculate every 0.5 seconds to avoid performance issues
+                let current_time = *crate::renderer::state::SIM_TIME.lock();
+                diag.calculate_if_needed(&self.bodies, &self.foils, &temp_quadtree, current_time, 0.5);
+                
                 for foil in &self.foils {
                     if let Some(frac) = diag.fractions.get(&foil.id) {
                         ui.horizontal(|ui| {

--- a/src/renderer/gui/diagnostics_tab.rs
+++ b/src/renderer/gui/diagnostics_tab.rs
@@ -61,6 +61,25 @@ impl super::super::Renderer {
 
         ui.separator();
 
+        // Foil electron fraction diagnostic
+        ui.group(|ui| {
+            ui.label("🔋 Foil Electron Ratio");
+            if let Some(diag) = &self.foil_electron_fraction_diagnostic {
+                for foil in &self.foils {
+                    if let Some(frac) = diag.fractions.get(&foil.id) {
+                        ui.horizontal(|ui| {
+                            ui.label(format!("Foil {}:", foil.id));
+                            ui.label(format!("{:.3}", frac));
+                        });
+                    }
+                }
+            } else {
+                ui.label("❌ No diagnostic data available.");
+            }
+        });
+
+        ui.separator();
+
         // Additional diagnostic information
         ui.group(|ui| {
             ui.label("📈 Simulation Statistics");

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -8,7 +8,7 @@ use crate::body::{Body, Species, foil::Foil};
 use crate::config::{SimConfig, DOMAIN_BOUNDS};
 use crate::quadtree::Node;
 use crate::plotting::{PlottingSystem, PlotType, Quantity, SamplingMode};
-use crate::diagnostics::TransferenceNumberDiagnostic;
+use crate::diagnostics::{TransferenceNumberDiagnostic, FoilElectronFractionDiagnostic};
 use ultraviolet::Vec2;
 use quarkstrom::winit_input_helper::WinitInputHelper;
 use std::collections::HashMap;
@@ -105,6 +105,7 @@ pub struct Renderer {
     // Current GUI tab
     pub current_tab: GuiTab,
     pub transference_number_diagnostic: Option<TransferenceNumberDiagnostic>,
+    pub foil_electron_fraction_diagnostic: Option<FoilElectronFractionDiagnostic>,
     
     // Screen capture functionality
     pub screen_capture_enabled: bool,
@@ -177,6 +178,7 @@ impl quarkstrom::Renderer for Renderer {
             selected_delete_option: DeleteOption::AllSpecies, // Default to All Species
             current_tab: GuiTab::default(), // Default to Simulation tab
             transference_number_diagnostic: Some(TransferenceNumberDiagnostic::new()),
+            foil_electron_fraction_diagnostic: Some(FoilElectronFractionDiagnostic::new()),
             
             // Screen capture defaults
             screen_capture_enabled: false,

--- a/src/renderer/screen_capture.rs
+++ b/src/renderer/screen_capture.rs
@@ -357,18 +357,6 @@ impl Renderer {
         Vec2::new(world_x, world_y)
     }
 
-    #[allow(dead_code)]
-    pub fn start_region_selection(&mut self, start_pos: Vec2) {
-        self.is_selecting_region = true;
-        self.selection_start = Some(start_pos);
-        self.selection_end = None;
-    }
-
-    #[allow(dead_code)]
-    pub fn update_region_selection(&mut self, end_pos: Vec2) {
-        self.selection_end = Some(end_pos);
-    }
-
     // Helper method to get the simulation window handle specifically
     pub fn get_simulation_window_handle(&self) -> Option<*mut std::ffi::c_void> {
         #[cfg(windows)]
@@ -482,6 +470,35 @@ impl Renderer {
             self.window_width = new_width;
             self.window_height = new_height;
         }
+    }
+
+    #[cfg(test)]
+    pub fn start_region_selection(&mut self, start: Vec2) {
+        self.is_selecting_region = true;
+        self.selection_start = Some(start);
+        self.selection_end = Some(start);
+        println!("Started region selection at ({:.1}, {:.1})", start.x, start.y);
+    }
+
+    #[cfg(test)]
+    pub fn update_region_selection(&mut self, end: Vec2) {
+        if self.is_selecting_region {
+            self.selection_end = Some(end);
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn world_to_screen(&self, world_pos: Vec2, width: u16, height: u16) -> Vec2 {
+        // Apply inverse camera transformation
+        let aspect_ratio = width as f32 / height as f32;
+        let x = (world_pos.x - self.pos.x) / (self.scale * aspect_ratio);
+        let y = (world_pos.y - self.pos.y) / self.scale;
+        
+        // Convert from normalized device coordinates to screen coordinates
+        let screen_x = (x + 1.0) * width as f32 / 2.0;
+        let screen_y = (1.0 - y) * height as f32 / 2.0;
+        
+        Vec2::new(screen_x, screen_y)
     }
 }
 


### PR DESCRIPTION
## Summary
- add `FoilElectronFractionDiagnostic` for electrode charge state
- compute this diagnostic each frame and expose it in GUI
- show foil electron ratio alongside transference numbers

## Testing
- `cargo test --quiet --offline` *(fails: can't fetch `quarkstrom` crate in offline mode)*

------
https://chatgpt.com/codex/tasks/task_b_687a8c4ae1b88332a7d0715777607710