### PR TITLE
Add species-specific electron polarization offset

### DIFF
--- a/src/app/command_loop.rs
+++ b/src/app/command_loop.rs
@@ -18,7 +18,7 @@ pub fn handle_command(cmd: SimCommand, simulation: &mut Simulation) {
                         let angle = fastrand::f32() * std::f32::consts::TAU;
                         let rel_pos = ultraviolet::Vec2::new(angle.cos(), angle.sin())
                             * body.radius
-                            * crate::config::ELECTRON_DRIFT_RADIUS_FACTOR;
+                            * body.species.polar_offset();
                         body.electrons.push(crate::body::Electron {
                             rel_pos,
                             vel: ultraviolet::Vec2::zero(),

--- a/src/body/electron.rs
+++ b/src/body/electron.rs
@@ -36,7 +36,7 @@ impl Body {
                 e.vel = e.vel / speed * max_speed;
             }
             e.rel_pos += e.vel * dt;
-            let max_dist = config::ELECTRON_DRIFT_RADIUS_FACTOR * self.radius;
+            let max_dist = self.species.polar_offset() * self.radius;
             if e.rel_pos.mag() > max_dist {
                 e.rel_pos = e.rel_pos.normalized() * max_dist;
             }
@@ -47,7 +47,7 @@ impl Body {
             let desired = 1 + (-self.charge).round() as usize;
             while self.electrons.len() < desired {
                 let angle = fastrand::f32() * std::f32::consts::TAU;
-                let rel_pos = Vec2::new(angle.cos(), angle.sin()) * self.radius * config::ELECTRON_DRIFT_RADIUS_FACTOR;
+                let rel_pos = Vec2::new(angle.cos(), angle.sin()) * self.radius * self.species.polar_offset();
                 self.electrons.push(Electron { rel_pos, vel: Vec2::zero() });
             }
             while self.electrons.len() > desired {

--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -184,4 +184,8 @@ impl Species {
     pub fn lj_cutoff(&self) -> f32 {
         self.props().lj_cutoff
     }
+
+    pub fn polar_offset(&self) -> f32 {
+        self.props().polar_offset
+    }
 }

--- a/src/commands/particle.rs
+++ b/src/commands/particle.rs
@@ -16,7 +16,7 @@ pub fn handle_change_charge(simulation: &mut Simulation, id: u64, delta: f32) {
                 let angle = fastrand::f32() * std::f32::consts::TAU;
                 let rel_pos = Vec2::new(angle.cos(), angle.sin())
                     * body.radius
-                    * crate::config::ELECTRON_DRIFT_RADIUS_FACTOR;
+                    * body.species.polar_offset();
                 body.electrons.push(Electron { rel_pos, vel: Vec2::zero() });
             }
         }

--- a/src/renderer/gui/species_tab.rs
+++ b/src/renderer/gui/species_tab.rs
@@ -156,6 +156,22 @@ impl super::super::Renderer {
             }
         });
 
+        ui.separator();
+
+        // Electron Polarization
+        ui.group(|ui| {
+            ui.label("🌀 Electron Polarization");
+            if ui
+                .add(
+                    egui::Slider::new(&mut current_props.polar_offset, 0.0..=1.5)
+                        .text("Drift Radius Factor"),
+                )
+                .changed()
+            {
+                changed = true;
+            }
+        });
+
         // Update species properties if changed
         if changed {
             crate::species::update_species_props(self.selected_lj_species, current_props);

--- a/src/species.rs
+++ b/src/species.rs
@@ -14,6 +14,7 @@ pub struct SpeciesProps {
     pub lj_epsilon: f32,
     pub lj_sigma: f32,
     pub lj_cutoff: f32,
+    pub polar_offset: f32,
 }
 
 pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(|| {
@@ -30,6 +31,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_epsilon: 0.0,
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            polar_offset: 0.0,
         },
     );
     m.insert(
@@ -43,6 +45,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_epsilon: crate::config::LJ_FORCE_EPSILON,
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
         },
     );
     m.insert(
@@ -56,6 +59,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_epsilon: crate::config::LJ_FORCE_EPSILON,
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            polar_offset: 0.0,
         },
     );
     m.insert(
@@ -69,6 +73,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_epsilon: 0.0,
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
         },
     );
     m.insert(
@@ -82,6 +87,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_epsilon: 0.0,
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
         },
     );
     m.insert(
@@ -95,6 +101,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_epsilon: 0.0,
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
         },
     );
     m
@@ -138,6 +145,7 @@ pub fn get_species_props(species: Species) -> SpeciesProps {
             lj_epsilon: 0.0,
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
+            polar_offset: 0.0,
         }
     })
 }


### PR DESCRIPTION
## Summary
- support per-species `polar_offset` editing in the GUI
- default `polar_offset` zero for species without electrons
- expose slider under Species tab

## Testing
- `cargo check` *(fails: could not fetch git dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6880d25815bc8332aa52e40a8707aeab