### PR TITLE
Implement species-specific polarization charge

### DIFF
--- a/docs/physics.md
+++ b/docs/physics.md
@@ -80,5 +80,8 @@ EC and DMC are modeled as neutral but polar molecules. Each carries a single
 bound electron that drifts within the molecule to form an electric dipole.
 During force calculation a polarization force is applied based on the
 difference between the electric field at the electron and at the molecular
-center. This allows charged particles to interact with the induced dipole so
-solvent shells form naturally without any Lennard-Jones attraction.
+center. To reproduce realistic dipole moments the electron does not carry a full
+elementary charge. Instead the effective charge is scaled per species
+(0.49e for EC and 0.054e for DMC). This allows charged particles to interact
+with the induced dipole so solvent shells form naturally without any
+Lennard-Jones attraction.

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,11 @@ pub const ELECTRON_SPRING_K_METAL: f32 = ELECTRON_SPRING_K; // Metal-specific sp
 pub const ELECTRON_SPRING_K_EC: f32 = ELECTRON_SPRING_K;    // EC-specific spring constant
 pub const ELECTRON_SPRING_K_DMC: f32 = ELECTRON_SPRING_K;   // DMC-specific spring constant
 
+// Effective polarization charge (in units of e) for solvent molecules
+pub const POLAR_CHARGE_EC: f32 = 0.49;
+pub const POLAR_CHARGE_DMC: f32 = 0.054;
+pub const POLAR_CHARGE_DEFAULT: f32 = 1.0;
+
 use crate::body::Species;
 
 /// Get the electron spring constant for a given species
@@ -26,6 +31,16 @@ pub const HOP_RADIUS_FACTOR: f32 = 2.1;                      // Hopping radius a
 pub const HOP_RATE_K0: f32 = 1.0;            /// Base hop‐rate constant (per unit time) at zero overpotential
 pub const HOP_TRANSFER_COEFF: f32 = 0.5;            /// Transfer coefficient α (unitless, ~0.5)   
 pub const HOP_ACTIVATION_ENERGY: f32 = 0.025;      /// Thermal energy k_BT (in your same charge‐units)
+
+/// Get the effective polarization charge for a given species
+pub fn polar_charge(species: Species) -> f32 {
+    use Species::*;
+    match species {
+        EC => POLAR_CHARGE_EC,
+        DMC => POLAR_CHARGE_DMC,
+        _ => POLAR_CHARGE_DEFAULT,
+    }
+}
 
 // ====================
 // Butler-Volmer Parameters

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -48,7 +48,9 @@ pub fn apply_polar_forces(sim: &mut Simulation) {
         if body.electrons.is_empty() { continue; }
         let e_pos = body.pos + body.electrons[0].rel_pos;
         let electron_field = quadtree.field_at_point(&bodies_snapshot, e_pos, K_E) + sim.background_e_field;
-        let force = body.e_field - electron_field;
+        let diff = body.e_field - electron_field;
+        let q_effective = config::polar_charge(body.species);
+        let force = diff * q_effective;
         body.acc += force / body.mass;
     }
 }


### PR DESCRIPTION
## Summary
- add polarization charge constants and helper
- scale polarization forces by the species charge
- document the effective charges in the physics notes

## Testing
- `cargo test --quiet` *(fails: couldn't fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6881930c98fc8332ba14ba01ffb111ae