### PR TITLE
Fix EC/DMC spawn electrons

### DIFF
--- a/src/app/command_loop.rs
+++ b/src/app/command_loop.rs
@@ -51,10 +51,7 @@ pub fn handle_command(cmd: SimCommand, simulation: &mut Simulation) {
         }
         SimCommand::AddBody { mut body } => {
             body.electrons.clear();
-            if matches!(
-                body.species,
-                crate::body::Species::LithiumMetal | crate::body::Species::ElectrolyteAnion
-            ) {
+            for _ in 0..body.neutral_electron_count() {
                 body.electrons.push(crate::body::Electron {
                     rel_pos: ultraviolet::Vec2::zero(),
                     vel: ultraviolet::Vec2::zero(),

--- a/src/app/spawn.rs
+++ b/src/app/spawn.rs
@@ -54,14 +54,8 @@ pub fn add_circle(
                 body.species,
             );
             new_body.electrons.clear();
-            if matches!(
-                new_body.species,
-                Species::LithiumMetal | Species::ElectrolyteAnion | Species::EC | Species::DMC
-            ) {
-                new_body.electrons.push(Electron {
-                    rel_pos: Vec2::zero(),
-                    vel: Vec2::zero(),
-                });
+            for _ in 0..new_body.neutral_electron_count() {
+                new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
             }
             new_body.update_charge_from_electrons();
             new_body.update_species();
@@ -86,14 +80,8 @@ pub fn add_ring(simulation: &mut Simulation, body: crate::body::Body, x: f32, y:
         let mut new_body =
             crate::body::Body::new(pos, Vec2::zero(), body.mass, body.radius, 0.0, body.species);
         new_body.electrons.clear();
-        if matches!(
-            new_body.species,
-            Species::LithiumMetal | Species::ElectrolyteAnion | Species::EC | Species::DMC
-        ) {
-            new_body.electrons.push(Electron {
-                rel_pos: Vec2::zero(),
-                vel: Vec2::zero(),
-            });
+        for _ in 0..new_body.neutral_electron_count() {
+            new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
         }
         new_body.update_charge_from_electrons();
         new_body.update_species();
@@ -133,14 +121,8 @@ pub fn add_rectangle(
                 body.species,
             );
             new_body.electrons.clear();
-            if matches!(
-                new_body.species,
-                Species::LithiumMetal | Species::ElectrolyteAnion | Species::EC | Species::DMC
-            ) {
-                new_body.electrons.push(Electron {
-                    rel_pos: Vec2::zero(),
-                    vel: Vec2::zero(),
-                });
+            for _ in 0..new_body.neutral_electron_count() {
+                new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
             }
             new_body.update_charge_from_electrons();
             new_body.update_species();
@@ -175,7 +157,7 @@ pub fn add_random(
                     body.species,
                 );
                 new_body.electrons.clear();
-                if matches!(new_body.species, Species::LithiumMetal | Species::ElectrolyteAnion | Species::EC | Species::DMC) {
+                for _ in 0..new_body.neutral_electron_count() {
                     new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
                 }
                 new_body.update_charge_from_electrons();
@@ -227,7 +209,9 @@ pub fn add_foil(
                 0.0,
                 Species::FoilMetal,
             );
-            new_body.electrons = smallvec![Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() }; crate::config::FOIL_NEUTRAL_ELECTRONS];
+            for _ in 0..new_body.neutral_electron_count() {
+                new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
+            }
             new_body.update_charge_from_electrons();
             body_ids.push(new_body.id);
             simulation.bodies.push(new_body);

--- a/src/commands/foil.rs
+++ b/src/commands/foil.rs
@@ -28,7 +28,9 @@ pub fn handle_add_foil(simulation: &mut Simulation, width: f32, height: f32, x: 
                 0.0,
                 Species::FoilMetal,
             );
-            new_body.electrons = smallvec::smallvec![Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() }; crate::config::FOIL_NEUTRAL_ELECTRONS];
+            for _ in 0..new_body.neutral_electron_count() {
+                new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
+            }
             new_body.update_charge_from_electrons();
             body_ids.push(new_body.id);
             simulation.bodies.push(new_body);

--- a/src/commands/particle.rs
+++ b/src/commands/particle.rs
@@ -63,8 +63,11 @@ pub fn handle_change_charge(simulation: &mut Simulation, id: u64, delta: f32) {
 
 pub fn handle_add_body(simulation: &mut Simulation, body: &mut crate::body::Body) {
     body.electrons.clear();
-    if matches!(body.species, Species::LithiumMetal | Species::ElectrolyteAnion) {
-        body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
+    for _ in 0..body.neutral_electron_count() {
+        body.electrons.push(Electron {
+            rel_pos: Vec2::zero(),
+            vel: Vec2::zero(),
+        });
     }
     body.update_charge_from_electrons();
     body.update_species();
@@ -128,7 +131,7 @@ pub fn handle_add_circle(
                 body.species,
             );
             new_body.electrons.clear();
-            if matches!(new_body.species, Species::LithiumMetal | Species::ElectrolyteAnion) {
+            for _ in 0..new_body.neutral_electron_count() {
                 new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
             }
             new_body.update_charge_from_electrons();
@@ -166,7 +169,7 @@ pub fn handle_add_ring(
             body.species,
         );
         new_body.electrons.clear();
-        if matches!(new_body.species, Species::LithiumMetal | Species::ElectrolyteAnion) {
+        for _ in 0..new_body.neutral_electron_count() {
             new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
         }
         new_body.update_charge_from_electrons();
@@ -207,7 +210,7 @@ pub fn handle_add_rectangle(
                 body.species,
             );
             new_body.electrons.clear();
-            if matches!(new_body.species, Species::LithiumMetal | Species::ElectrolyteAnion) {
+            for _ in 0..new_body.neutral_electron_count() {
                 new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
             }
             new_body.update_charge_from_electrons();
@@ -241,7 +244,7 @@ pub fn handle_add_random(
                     body.species,
                 );
                 new_body.electrons.clear();
-                if matches!(new_body.species, Species::LithiumMetal | Species::ElectrolyteAnion) {
+                for _ in 0..new_body.neutral_electron_count() {
                     new_body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
                 }
                 new_body.update_charge_from_electrons();

--- a/src/renderer/gui/scenario_tab.rs
+++ b/src/renderer/gui/scenario_tab.rs
@@ -449,52 +449,13 @@ pub fn make_body_with_species(
     radius: f32,
     species: Species,
 ) -> Body {
-    use crate::config::{FOIL_NEUTRAL_ELECTRONS, LITHIUM_METAL_NEUTRAL_ELECTRONS};
     let mut body = Body::new(pos, vel, mass, radius, 0.0, species);
     body.electrons.clear();
-    match species {
-        Species::LithiumMetal => {
-            for _ in 0..LITHIUM_METAL_NEUTRAL_ELECTRONS {
-                body.electrons.push(Electron {
-                    rel_pos: Vec2::zero(),
-                    vel: Vec2::zero(),
-                });
-            }
-        }
-        Species::FoilMetal => {
-            for _ in 0..FOIL_NEUTRAL_ELECTRONS {
-                body.electrons.push(Electron {
-                    rel_pos: Vec2::zero(),
-                    vel: Vec2::zero(),
-                });
-            }
-        }
-        Species::LithiumIon => {
-            // Ions: one less electron than neutral metal, positive charge
-            if LITHIUM_METAL_NEUTRAL_ELECTRONS > 0 {
-                for _ in 0..(LITHIUM_METAL_NEUTRAL_ELECTRONS - 1) {
-                    body.electrons.push(Electron {
-                        rel_pos: Vec2::zero(),
-                        vel: Vec2::zero(),
-                    });
-                }
-            }
-        }
-        Species::ElectrolyteAnion => {
-            // Anions: one more electron than neutral metal, negative charge
-            if LITHIUM_METAL_NEUTRAL_ELECTRONS > 0 {
-                for _ in 0..(LITHIUM_METAL_NEUTRAL_ELECTRONS + 1) {
-                    body.electrons.push(Electron {
-                        rel_pos: Vec2::zero(),
-                        vel: Vec2::zero(),
-                    });
-                }
-            }
-        }
-        Species::EC | Species::DMC => {
-            // Neutral solvent molecules with a single drifting electron
-            body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
-        }
+    for _ in 0..body.neutral_electron_count() {
+        body.electrons.push(Electron {
+            rel_pos: Vec2::zero(),
+            vel: Vec2::zero(),
+        });
     }
     body.update_charge_from_electrons();
     body.update_species();


### PR DESCRIPTION
## Summary
- ensure EC and DMC molecules start neutral when spawned individually
- initialize electrons for all created bodies using each species' `neutral_electron_count` value
- create GUI bodies using the same neutral electron count logic

## Testing
- `cargo check --quiet` *(fails to fetch crates)*
- `cargo test --quiet` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_b_6882378575dc83329256119438791ec6