### PR TITLE
Fix EC/DMC spawn electrons

### DIFF
--- a/src/app/command_loop.rs
+++ b/src/app/command_loop.rs
@@ -53,7 +53,10 @@ pub fn handle_command(cmd: SimCommand, simulation: &mut Simulation) {
             body.electrons.clear();
             if matches!(
                 body.species,
-                crate::body::Species::LithiumMetal | crate::body::Species::ElectrolyteAnion
+                crate::body::Species::LithiumMetal
+                    | crate::body::Species::ElectrolyteAnion
+                    | crate::body::Species::EC
+                    | crate::body::Species::DMC
             ) {
                 body.electrons.push(crate::body::Electron {
                     rel_pos: ultraviolet::Vec2::zero(),

--- a/src/commands/particle.rs
+++ b/src/commands/particle.rs
@@ -63,8 +63,14 @@ pub fn handle_change_charge(simulation: &mut Simulation, id: u64, delta: f32) {
 
 pub fn handle_add_body(simulation: &mut Simulation, body: &mut crate::body::Body) {
     body.electrons.clear();
-    if matches!(body.species, Species::LithiumMetal | Species::ElectrolyteAnion) {
-        body.electrons.push(Electron { rel_pos: Vec2::zero(), vel: Vec2::zero() });
+    if matches!(
+        body.species,
+        Species::LithiumMetal | Species::ElectrolyteAnion | Species::EC | Species::DMC
+    ) {
+        body.electrons.push(Electron {
+            rel_pos: Vec2::zero(),
+            vel: Vec2::zero(),
+        });
     }
     body.update_charge_from_electrons();
     body.update_species();


### PR DESCRIPTION
## Summary
- ensure EC and DMC molecules start neutral when spawned individually

## Testing
- `cargo test --quiet` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_b_6882378575dc83329256119438791ec6