### PR TITLE
Support domain width/height and random defaults

### DIFF
--- a/init_config.toml
+++ b/init_config.toml
@@ -3,8 +3,9 @@
 # Note: All positions (x, y) are CENTER coordinates, not corner coordinates
 
 [simulation]
-# Domain bounds (radius from center, so total width/height = 2 * domain_bounds)
-domain_bounds = 200.0
+# Domain size (full width/height of the simulation domain)
+domain_width = 400.0
+domain_height = 400.0
 
 [particles]
 # Metal rectangles (positions are center coordinates)
@@ -41,26 +42,18 @@ current = 0.0
 [[particles.random]]
 count = 450
 species = "ElectrolyteAnion"
-domain_width = 400.0  # Full domain width
-domain_height = 400.0 # domain height
 
 [[particles.random]]
 count = 450
 species = "LithiumIon"
-domain_width = 400.0
-domain_height = 400.0
 
 [[particles.random]]
 count = 3370
 species = "EC"
-domain_width = 400.0
-domain_height = 400.0
 
 [[particles.random]]
 count = 2673
 species = "DMC"
-domain_width = 400.0
-domain_height = 400.0
 
 # Legacy circle configurations (commented out)
 # [[particles.circles]]

--- a/init_config.toml
+++ b/init_config.toml
@@ -5,7 +5,7 @@
 [simulation]
 # Domain size (full width/height of the simulation domain)
 domain_width = 400.0
-domain_height = 400.0
+domain_height = 300.0
 
 [particles]
 # Metal rectangles (positions are center coordinates)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -49,17 +49,21 @@ pub fn run() {
 
     let tx = SIM_COMMAND_SENDER.lock().as_ref().unwrap().clone();
 
-    if let Some(ref sim_config) = init_config.simulation {
-        if let Some(domain_bounds) = sim_config.domain_bounds {
-            println!("Setting domain bounds to: {}", domain_bounds);
-            let domain_size = domain_bounds * 2.0;
-            tx.send(SimCommand::SetDomainSize {
-                width: domain_size,
-                height: domain_size,
-            })
-            .unwrap();
-        }
-    }
+    // Determine the domain size from configuration
+    let (global_width, global_height) = if let Some(ref sim_config) = init_config.simulation {
+        let width = sim_config
+            .domain_width
+            .unwrap_or(crate::config::DOMAIN_BOUNDS * 2.0);
+        let height = sim_config
+            .domain_height
+            .unwrap_or(crate::config::DOMAIN_BOUNDS * 2.0);
+        println!("Setting domain size to {}x{}", width, height);
+        tx.send(SimCommand::SetDomainSize { width, height }).unwrap();
+        (width, height)
+    } else {
+        let size = crate::config::DOMAIN_BOUNDS * 2.0;
+        (size, size)
+    };
 
     let metal_body = crate::body::Body::new(
         Vec2::zero(),
@@ -203,19 +207,25 @@ pub fn run() {
                     Species::EC => ec_body.clone(),
                     Species::DMC => dmc_body.clone(),
                 };
+                let width = random_config
+                    .domain_width
+                    .unwrap_or(global_width);
+                let height = random_config
+                    .domain_height
+                    .unwrap_or(global_height);
                 tx.send(SimCommand::AddRandom {
                     body,
                     count: random_config.count,
-                    domain_width: random_config.domain_width,
-                    domain_height: random_config.domain_height,
+                    domain_width: width,
+                    domain_height: height,
                 })
                 .unwrap();
                 println!(
                     "Added {} random {} particles in {}x{} domain",
                     random_config.count,
                     random_config.species,
-                    random_config.domain_width,
-                    random_config.domain_height
+                    width,
+                    height
                 );
             }
             Err(e) => eprintln!("Error in random config: {}", e),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -51,12 +51,7 @@ pub fn run() {
 
     // Determine the domain size from configuration
     let (global_width, global_height) = if let Some(ref sim_config) = init_config.simulation {
-        let width = sim_config
-            .domain_width
-            .unwrap_or(crate::config::DOMAIN_BOUNDS * 2.0);
-        let height = sim_config
-            .domain_height
-            .unwrap_or(crate::config::DOMAIN_BOUNDS * 2.0);
+        let (width, height) = sim_config.domain_size();
         println!("Setting domain size to {}x{}", width, height);
         tx.send(SimCommand::SetDomainSize { width, height }).unwrap();
         (width, height)

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -20,6 +20,17 @@ pub struct SimulationConfig {
     pub domain_height: Option<f32>,
 }
 
+impl SimulationConfig {
+    /// Return the domain width and height, using the global defaults when values are not provided.
+    pub fn domain_size(&self) -> (f32, f32) {
+        let default = crate::config::DOMAIN_BOUNDS * 2.0;
+        (
+            self.domain_width.unwrap_or(default),
+            self.domain_height.unwrap_or(default),
+        )
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ParticlesConfig {
     #[serde(default)]

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -14,7 +14,10 @@ pub struct InitConfig {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SimulationConfig {
-    pub domain_bounds: Option<f32>,
+    /// Optional simulation domain width. Falls back to the default when omitted.
+    pub domain_width: Option<f32>,
+    /// Optional simulation domain height. Falls back to the default when omitted.
+    pub domain_height: Option<f32>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -59,8 +62,10 @@ pub struct FoilRectangleConfig {
 pub struct RandomConfig {
     pub count: usize,
     pub species: String,
-    pub domain_width: f32,
-    pub domain_height: f32,
+    /// Optional override for the domain width used when placing particles
+    pub domain_width: Option<f32>,
+    /// Optional override for the domain height used when placing particles
+    pub domain_height: Option<f32>,
 }
 
 impl InitConfig {

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -32,12 +32,7 @@ fn apply_configuration(init_config: InitConfig) -> Result<(), Box<dyn std::error
     
     // Determine domain size from config or fallback constant
     let (global_width, global_height) = if let Some(ref sim_config) = init_config.simulation {
-        let width = sim_config
-            .domain_width
-            .unwrap_or(crate::config::DOMAIN_BOUNDS * 2.0);
-        let height = sim_config
-            .domain_height
-            .unwrap_or(crate::config::DOMAIN_BOUNDS * 2.0);
+        let (width, height) = sim_config.domain_size();
         println!("Setting domain size to {}x{}", width, height);
         tx.send(SimCommand::SetDomainSize { width, height })?;
         (width, height)


### PR DESCRIPTION
## Summary
- allow specifying `domain_width` and `domain_height` in `SimulationConfig`
- default random particle placement to the global domain when per-entry dimensions are omitted
- update scenario and app logic to use the new fields
- adjust example `init_config.toml`

## Testing
- `cargo check` *(fails: failed to fetch dependency quarkstrom)*

------
https://chatgpt.com/codex/tasks/task_b_68827341d2248332b82aea642d4fae6b