### PR TITLE
Add AGENT documentation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,10 @@
+# Codex Agent Instructions
+
+This repository is a Rust project that simulates electrochemical particle systems.
+
+## Programmatic Checks
+- Run `cargo check` before committing changes to verify the project compiles.
+- The `cargo test` suite relies on features that do not function in the Codex environment, so it is unnecessary to run `cargo test` here.
+
+## Module Guides
+Each major module under `src/` has its own `AGENT.md` file describing the module and key files.

--- a/src/app/AGENT.md
+++ b/src/app/AGENT.md
@@ -1,0 +1,9 @@
+# Module: app
+
+High-level application control and initialization code.
+
+Files:
+- `command_loop.rs` – processes commands from the GUI or input.
+- `simulation_loop.rs` – drives simulation updates on a separate thread.
+- `spawn.rs` – utilities for spawning particles without overlaps.
+- `mod.rs` – entry point; sets up the renderer and simulation.

--- a/src/body/AGENT.md
+++ b/src/body/AGENT.md
@@ -1,0 +1,10 @@
+# Module: body
+
+Defines particle structures and behaviors.
+
+Key files:
+- `electron.rs` – electron representation.
+- `foil.rs` – foil body behavior.
+- `redox.rs` – species transitions based on electron count.
+- `types.rs` – core `Body`, `Electron`, and species definitions.
+- `tests/` and `tests.rs` – unit tests (these require features that may not run in Codex).

--- a/src/commands/AGENT.md
+++ b/src/commands/AGENT.md
@@ -1,0 +1,10 @@
+# Module: commands
+
+Processes simulation commands issued from the GUI.
+
+Files:
+- `dispatcher.rs` – routes `SimCommand` variants to handlers.
+- `particle.rs` – command handlers related to particles and domain size.
+- `foil.rs` – command handlers related to foil currents and linking.
+- `state.rs` – commands for saving/loading or stepping the simulation.
+- `mod.rs` – re-exports `process_command`.

--- a/src/diagnostics/AGENT.md
+++ b/src/diagnostics/AGENT.md
@@ -1,0 +1,8 @@
+# Module: diagnostics
+
+Real-time diagnostic calculations shown in the GUI.
+
+Files:
+- `transference_number.rs` – computes transient ion transference numbers.
+- `foil_electron_fraction.rs` – tracks electron fractions for foil particles.
+- `mod.rs` – re-exports diagnostic helpers.

--- a/src/plotting/AGENT.md
+++ b/src/plotting/AGENT.md
@@ -1,0 +1,9 @@
+# Module: plotting
+
+Provides analysis and plotting utilities for visualizing simulation data.
+
+Files:
+- `analysis.rs` – statistical analysis helpers for species counts and profiles.
+- `export.rs` – serialization of plot data to disk.
+- `gui.rs` – GUI windows for plots.
+- `mod.rs` – main plotting system types and enums.

--- a/src/quadtree/AGENT.md
+++ b/src/quadtree/AGENT.md
@@ -1,0 +1,10 @@
+# Module: quadtree
+
+Barnes-Hut spatial partitioning for fast force computation.
+
+Files:
+- `node.rs` – tree node structure storing mass, center-of-mass, and children.
+- `quad.rs` – utilities for quadrant bounds.
+- `quadtree.rs` – main quadtree building and traversal logic.
+- `tests.rs` – unit tests for quadtree behavior.
+- `mod.rs` – module declarations and re-exports.

--- a/src/renderer/AGENT.md
+++ b/src/renderer/AGENT.md
@@ -1,0 +1,12 @@
+# Module: renderer
+
+Handles all graphics, input, and GUI elements.
+
+Files:
+- `state.rs` – renderer state and command definitions.
+- `input.rs` – mapping of window events to simulation commands.
+- `gui.rs` – GUI logic for simulation controls and diagnostics.
+- `draw/` – primitive drawing routines for charges, fields, and waves.
+- `screen_capture.rs` – output frames to images or video.
+- `tests.rs` – renderer-related tests.
+- `mod.rs` – orchestrates the rendering subsystem.

--- a/src/renderer/draw/AGENT.md
+++ b/src/renderer/draw/AGENT.md
@@ -1,0 +1,9 @@
+# Module: renderer::draw
+
+Low-level drawing primitives used by the renderer.
+
+Files:
+- `charge.rs` – visualize particle charges as circles.
+- `field.rs` – electric field visualizations.
+- `foil_wave.rs` – animation of foil current waves.
+- `mod.rs` – exports drawing helper functions.

--- a/src/simulation/AGENT.md
+++ b/src/simulation/AGENT.md
@@ -1,0 +1,11 @@
+# Module: simulation
+
+Core physics engine and stepping logic.
+
+Files:
+- `forces.rs` – force calculations (electrostatics, etc.).
+- `collision.rs` – particle collision resolution.
+- `simulation.rs` – main `Simulation` struct and step function.
+- `utils.rs` – small helpers for integrators or statistics.
+- `tests.rs` – unit tests (may not run under Codex).
+- `mod.rs` – re-exports module contents.


### PR DESCRIPTION
## Summary
- document project instructions in new `AGENT.md`
- add module guides in `src/*/AGENT.md` for easier navigation

## Testing
- `cargo check` *(fails: could not fetch `quarkstrom` crate)*

------
https://chatgpt.com/codex/tasks/task_b_688279ca4a50833282b476ec6bd929cd