### PR TITLE
Expose Coulomb constant in GUI

### DIFF
--- a/src/body/electron.rs
+++ b/src/body/electron.rs
@@ -21,12 +21,13 @@ impl Body {
         quadtree: &Quadtree,
         background_field: Vec2,
         dt: f32,
+        coulomb_constant: f32,
     ) {
         let k = config::electron_spring_k(self.species);
         for e in &mut self.electrons {
             let electron_pos = self.pos + e.rel_pos;
             let local_field =
-                quadtree.field_at_point(bodies, electron_pos, crate::simulation::forces::K_E)
+                quadtree.field_at_point(bodies, electron_pos, coulomb_constant)
                     + background_field;
             let acc = -local_field * k;
             e.vel += acc * dt;

--- a/src/body/tests.rs
+++ b/src/body/tests.rs
@@ -149,7 +149,7 @@ mod tests {
             println!("After qt.build");
             let bodies_clone = bodies.clone();
             println!("Before update: rel_pos = {:?}, vel = {:?}", bodies[0].electrons[0].rel_pos, bodies[0].electrons[0].vel);
-            bodies[0].update_electrons(&bodies_clone, &qt, field, 0.1);
+            bodies[0].update_electrons(&bodies_clone, &qt, field, 0.1, crate::simulation::forces::K_E);
             println!("After update: rel_pos = {:?}, vel = {:?}", bodies[0].electrons[0].rel_pos, bodies[0].electrons[0].vel);
             assert!(bodies[0].electrons[0].rel_pos.x < 0.0,
                 "Expected electron to drift left (x < 0), but rel_pos.x = {}", bodies[0].electrons[0].rel_pos.x);

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,7 @@ pub struct SimConfig {
     pub lj_force_epsilon: f32,
     pub lj_force_sigma: f32,
     pub lj_force_cutoff: f32,
+    pub coulomb_constant: f32,
 }
 
 impl Default for SimConfig {
@@ -187,6 +188,7 @@ impl Default for SimConfig {
             lj_force_epsilon: LJ_FORCE_EPSILON,
             lj_force_sigma: LJ_FORCE_SIGMA,
             lj_force_cutoff: LJ_FORCE_CUTOFF,
+            coulomb_constant: crate::simulation::forces::K_E,
         }
     }
 }

--- a/src/renderer/draw/field.rs
+++ b/src/renderer/draw/field.rs
@@ -172,7 +172,7 @@ pub fn compute_potential_at_point(
         for body in bodies {
             let r = pos - body.pos;
             let dist = r.mag().max(1e-4);
-            potential += crate::simulation::forces::K_E * body.charge / dist;
+            potential += config.coulomb_constant * body.charge / dist;
         }
     }
 

--- a/src/renderer/gui/physics_tab.rs
+++ b/src/renderer/gui/physics_tab.rs
@@ -93,5 +93,18 @@ impl super::super::Renderer {
             ui.label("• External field affects all particles uniformly");
             ui.label("• Adjust in Simulation tab for basic controls");
         });
+
+        ui.separator();
+
+        // Coulomb constant control
+        ui.group(|ui| {
+            ui.label("🔌 Coulomb Constant");
+            ui.add(
+                egui::Slider::new(&mut self.sim_config.coulomb_constant, 1000.0..=20000.0)
+                    .text("k_e")
+                    .step_by(1.0)
+                    .logarithmic(true),
+            );
+        });
     }
 }

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -18,7 +18,7 @@ pub const K_E: f32 = 8.988e3 * 0.5;
 pub fn attract(sim: &mut Simulation) {
     profile_scope!("forces_attract");
     sim.quadtree.build(&mut sim.bodies);
-    sim.quadtree.field(&mut sim.bodies, K_E);
+    sim.quadtree.field(&mut sim.bodies, sim.config.coulomb_constant);
     for body in &mut sim.bodies {
         body.e_field += sim.background_e_field;
     }
@@ -74,13 +74,14 @@ pub fn apply_polar_forces(sim: &mut Simulation) {
                 continue;
             }
 
+            let k_e = sim.config.coulomb_constant;
             let field_from = |point: ultraviolet::Vec2, point_radius: f32| {
                 let d = point - sim.bodies[j].pos;
                 let dist = d.mag();
                 let min_sep = point_radius + sim.bodies[j].radius;
                 let r_eff = dist.max(min_sep);
                 let denom = (r_eff * r_eff + epsilon_sq) * r_eff;
-                d * (K_E * sim.bodies[j].charge / denom)
+                d * (k_e * sim.bodies[j].charge / denom)
             };
 
             let field_nucleus = field_from(sim.bodies[i].pos, sim.bodies[i].radius);

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -134,7 +134,13 @@ impl Simulation {
         for i in 0..len {
             let bodies_slice = unsafe { std::slice::from_raw_parts(bodies_ptr, len) };
             let body = &mut self.bodies[i];
-            body.update_electrons(bodies_slice, quadtree, self.background_e_field, self.dt);
+            body.update_electrons(
+                bodies_slice,
+                quadtree,
+                self.background_e_field,
+                self.dt,
+                self.config.coulomb_constant,
+            );
             body.update_charge_from_electrons();
         }
         self.perform_electron_hopping_with_exclusions(&foil_current_recipients);
@@ -241,7 +247,7 @@ impl Simulation {
                 let hop_vec = dst_body.pos - src_body.pos;
                 let hop_dir = if hop_vec.mag() > 1e-6 { hop_vec.normalized() } else { Vec2::zero() };
                 let local_field = self.background_e_field
-                    + self.quadtree.field_at_point(&self.bodies, src_body.pos, crate::simulation::forces::K_E);
+                    + self.quadtree.field_at_point(&self.bodies, src_body.pos, self.config.coulomb_constant);
                 let field_dir = if local_field.mag() > 1e-6 { local_field.normalized() } else { Vec2::zero() };
                 let mut alignment = (-hop_dir.dot(field_dir)).max(0.0);
                 if field_dir == Vec2::zero() { alignment = 1.0; }


### PR DESCRIPTION
## Summary
- add `coulomb_constant` to `SimConfig`
- allow the physics tab to edit Coulomb's constant
- pass the configurable constant into force calculations and electron updates
- show Coulomb constant in potential overlay

## Testing
- `cargo check` *(fails: could not fetch git dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6882ea30e9ac833286d62ac6fcc73cde