### PR TITLE
add polar charge control

### DIFF
--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -188,4 +188,8 @@ impl Species {
     pub fn polar_offset(&self) -> f32 {
         self.props().polar_offset
     }
+
+    pub fn polar_charge(&self) -> f32 {
+        self.props().polar_charge
+    }
 }

--- a/src/renderer/gui/species_tab.rs
+++ b/src/renderer/gui/species_tab.rs
@@ -170,6 +170,15 @@ impl super::super::Renderer {
             {
                 changed = true;
             }
+            if ui
+                .add(
+                    egui::Slider::new(&mut current_props.polar_charge, 0.0..=1.0)
+                        .text("Effective Charge"),
+                )
+                .changed()
+            {
+                changed = true;
+            }
         });
 
         // Update species properties if changed
@@ -195,6 +204,10 @@ impl super::super::Renderer {
                 ui.label(format!("Mass: {:.2}", current_props.mass));
                 ui.label(format!("Radius: {:.2}", current_props.radius));
                 ui.label(format!("Damping: {:.3}", current_props.damping));
+            });
+            ui.horizontal(|ui| {
+                ui.label(format!("Polar offset: {:.2}", current_props.polar_offset));
+                ui.label(format!("Polar charge: {:.2}", current_props.polar_charge));
             });
             if current_props.lj_enabled {
                 ui.horizontal(|ui| {

--- a/src/simulation/forces.rs
+++ b/src/simulation/forces.rs
@@ -85,7 +85,7 @@ pub fn apply_polar_forces(sim: &mut Simulation) {
 
             let field_nucleus = field_from(sim.bodies[i].pos, sim.bodies[i].radius);
             let field_electron = field_from(e_pos, 0.0);
-            let q_eff = config::polar_charge(sim.bodies[i].species);
+            let q_eff = sim.bodies[i].species.polar_charge();
             let force = (field_nucleus - field_electron) * q_eff;
 
             if i < j {

--- a/src/species.rs
+++ b/src/species.rs
@@ -15,6 +15,7 @@ pub struct SpeciesProps {
     pub lj_sigma: f32,
     pub lj_cutoff: f32,
     pub polar_offset: f32,
+    pub polar_charge: f32,
 }
 
 pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(|| {
@@ -32,6 +33,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
+            polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
         },
     );
     m.insert(
@@ -46,6 +48,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
+            polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
         },
     );
     m.insert(
@@ -60,6 +63,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
+            polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
         },
     );
     m.insert(
@@ -74,6 +78,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
+            polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
         },
     );
     m.insert(
@@ -88,6 +93,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
+            polar_charge: crate::config::POLAR_CHARGE_EC,
         },
     );
     m.insert(
@@ -102,6 +108,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
+            polar_charge: crate::config::POLAR_CHARGE_DMC,
         },
     );
     m
@@ -146,6 +153,7 @@ pub fn get_species_props(species: Species) -> SpeciesProps {
             lj_sigma: crate::config::LJ_FORCE_SIGMA,
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
+            polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
         }
     })
 }


### PR DESCRIPTION
## Summary
- expose a polar charge value for each species
- display and edit the value in the species configuration tab
- apply per-species polar charge when computing polarization forces

## Testing
- `cargo check` *(fails: failed to load source for dependency `quarkstrom`)*

------
https://chatgpt.com/codex/tasks/task_b_68842d76caf0833289e2b19be4ab3a7a