### PR TITLE
Add repulsive potential toggle per species

### DIFF
--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -192,4 +192,16 @@ impl Species {
     pub fn polar_charge(&self) -> f32 {
         self.props().polar_charge
     }
+
+    pub fn repulsion_enabled(&self) -> bool {
+        self.props().enable_repulsion
+    }
+
+    pub fn repulsion_strength(&self) -> f32 {
+        self.props().repulsion_strength
+    }
+
+    pub fn repulsion_cutoff(&self) -> f32 {
+        self.props().repulsion_cutoff
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,14 +33,14 @@ pub const HOP_TRANSFER_COEFF: f32 = 0.5;            /// Transfer coefficient α 
 pub const HOP_ACTIVATION_ENERGY: f32 = 0.025;      /// Thermal energy k_BT (in your same charge‐units)
 
 /// Get the effective polarization charge for a given species
-pub fn polar_charge(species: Species) -> f32 {
+/* 
     use Species::*;
     match species {
         EC => POLAR_CHARGE_EC,
         DMC => POLAR_CHARGE_DMC,
         _ => POLAR_CHARGE_DEFAULT,
     }
-}
+}*/
 
 // ====================
 // Butler-Volmer Parameters

--- a/src/renderer/gui/species_tab.rs
+++ b/src/renderer/gui/species_tab.rs
@@ -158,6 +158,41 @@ impl super::super::Renderer {
 
         ui.separator();
 
+        // Short-range Repulsion
+        ui.group(|ui| {
+            ui.label("🛑 Repulsive Potential");
+            if ui
+                .checkbox(&mut current_props.enable_repulsion, "Enable repulsive potential")
+                .changed()
+            {
+                changed = true;
+            }
+            if current_props.enable_repulsion {
+                if ui
+                    .add(
+                        egui::Slider::new(&mut current_props.repulsion_strength, 0.0..=20.0)
+                            .text("Strength k")
+                            .step_by(0.1),
+                    )
+                    .changed()
+                {
+                    changed = true;
+                }
+                if ui
+                    .add(
+                        egui::Slider::new(&mut current_props.repulsion_cutoff, 0.1..=5.0)
+                            .text("Cutoff r0")
+                            .step_by(0.01),
+                    )
+                    .changed()
+                {
+                    changed = true;
+                }
+            }
+        });
+
+        ui.separator();
+
         // Electron Polarization
         ui.group(|ui| {
             ui.label("🌀 Electron Polarization");
@@ -209,6 +244,12 @@ impl super::super::Renderer {
                 ui.label(format!("Polar offset: {:.2}", current_props.polar_offset));
                 ui.label(format!("Polar charge: {:.2}", current_props.polar_charge));
             });
+            if current_props.enable_repulsion {
+                ui.horizontal(|ui| {
+                    ui.label(format!("Repulsion k: {:.2}", current_props.repulsion_strength));
+                    ui.label(format!("Repulsion r0: {:.2}", current_props.repulsion_cutoff));
+                });
+            }
             if current_props.lj_enabled {
                 ui.horizontal(|ui| {
                     ui.label(format!("LJ ε: {:.1}", current_props.lj_epsilon));

--- a/src/renderer/gui/species_tab.rs
+++ b/src/renderer/gui/species_tab.rs
@@ -80,7 +80,7 @@ impl super::super::Renderer {
             // Damping control
             if ui
                 .add(
-                    egui::Slider::new(&mut current_props.damping, 0.1..=1.0)
+                    egui::Slider::new(&mut current_props.damping, 0.01..=1.0)
                         .text("Damping")
                         .step_by(0.001),
                 )
@@ -170,7 +170,7 @@ impl super::super::Renderer {
             if current_props.enable_repulsion {
                 if ui
                     .add(
-                        egui::Slider::new(&mut current_props.repulsion_strength, 0.0..=20.0)
+                        egui::Slider::new(&mut current_props.repulsion_strength, 0.0..=100.0)
                             .text("Strength k")
                             .step_by(0.1),
                     )
@@ -180,7 +180,7 @@ impl super::super::Renderer {
                 }
                 if ui
                     .add(
-                        egui::Slider::new(&mut current_props.repulsion_cutoff, 0.1..=5.0)
+                        egui::Slider::new(&mut current_props.repulsion_cutoff, 0.1..=20.0)
                             .text("Cutoff r0")
                             .step_by(0.01),
                     )

--- a/src/simulation/simulation.rs
+++ b/src/simulation/simulation.rs
@@ -97,6 +97,7 @@ impl Simulation {
         forces::attract(self);
         forces::apply_polar_forces(self);
         forces::apply_lj_forces(self);
+        forces::apply_repulsive_forces(self);
         self.iterate();
         let num_passes = *COLLISION_PASSES.lock();
         for _ in 1..num_passes {

--- a/src/species.rs
+++ b/src/species.rs
@@ -16,6 +16,9 @@ pub struct SpeciesProps {
     pub lj_cutoff: f32,
     pub polar_offset: f32,
     pub polar_charge: f32,
+    pub enable_repulsion: bool,
+    pub repulsion_strength: f32,
+    pub repulsion_cutoff: f32,
 }
 
 pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(|| {
@@ -34,6 +37,9 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            enable_repulsion: false,
+            repulsion_strength: 5.0,
+            repulsion_cutoff: 2.0,
         },
     );
     m.insert(
@@ -49,6 +55,9 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            enable_repulsion: false,
+            repulsion_strength: 5.0,
+            repulsion_cutoff: 2.0,
         },
     );
     m.insert(
@@ -64,6 +73,9 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            enable_repulsion: false,
+            repulsion_strength: 5.0,
+            repulsion_cutoff: 2.0,
         },
     );
     m.insert(
@@ -79,6 +91,9 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            enable_repulsion: false,
+            repulsion_strength: 5.0,
+            repulsion_cutoff: 2.0,
         },
     );
     m.insert(
@@ -94,6 +109,9 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
             polar_charge: crate::config::POLAR_CHARGE_EC,
+            enable_repulsion: false,
+            repulsion_strength: 5.0,
+            repulsion_cutoff: 2.0,
         },
     );
     m.insert(
@@ -109,6 +127,9 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR,
             polar_charge: crate::config::POLAR_CHARGE_DMC,
+            enable_repulsion: false,
+            repulsion_strength: 5.0,
+            repulsion_cutoff: 2.0,
         },
     );
     m
@@ -124,6 +145,19 @@ pub fn max_lj_cutoff() -> f32 {
         .map(|&species| get_species_props(species))
         .filter(|p| p.lj_enabled)
         .map(|p| p.lj_cutoff * p.lj_sigma)
+        .fold(0.0_f32, f32::max)
+}
+
+/// Maximum repulsion cutoff across all species.
+pub fn max_repulsion_cutoff() -> f32 {
+    use Species::*;
+    let species_list = [LithiumIon, LithiumMetal, FoilMetal, ElectrolyteAnion, EC, DMC];
+
+    species_list
+        .iter()
+        .map(|&species| get_species_props(species))
+        .filter(|p| p.enable_repulsion)
+        .map(|p| p.repulsion_cutoff)
         .fold(0.0_f32, f32::max)
 }
 
@@ -154,6 +188,9 @@ pub fn get_species_props(species: Species) -> SpeciesProps {
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            enable_repulsion: false,
+            repulsion_strength: 5.0,
+            repulsion_cutoff: 2.0,
         }
     })
 }


### PR DESCRIPTION
## Summary
- allow enabling a repulsive potential per species
- expose repulsion parameters in the species GUI
- compute short-range repulsion forces
- apply repulsion in the simulation step

## Testing
- `cargo check` *(fails: failed to fetch git dependency)*

------
https://chatgpt.com/codex/tasks/task_b_6884be788924833294c8a9e6dc5c166a