### PR TITLE
Add solvation diagnostic

### DIFF
--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -3,6 +3,8 @@
 
 pub mod transference_number;
 pub mod foil_electron_fraction;
+pub mod solvation;
 
 pub use transference_number::*;
 pub use foil_electron_fraction::*;
+pub use solvation::*;

--- a/src/diagnostics/solvation.rs
+++ b/src/diagnostics/solvation.rs
@@ -1,0 +1,123 @@
+// diagnostics/solvation.rs
+// Calculates coordination numbers and solvation state distribution
+
+use crate::body::{Body, Species};
+use crate::simulation::compute_temperature;
+
+pub struct SolvationDiagnostic {
+    pub temperature: f32,
+    pub avg_li_coordination: f32,
+    pub avg_anion_coordination: f32,
+    pub cip_fraction: f32,
+    pub sip_fraction: f32,
+    pub s2ip_fraction: f32,
+    pub fd_fraction: f32,
+}
+
+impl SolvationDiagnostic {
+    pub fn new() -> Self {
+        Self {
+            temperature: 0.0,
+            avg_li_coordination: 0.0,
+            avg_anion_coordination: 0.0,
+            cip_fraction: 0.0,
+            sip_fraction: 0.0,
+            s2ip_fraction: 0.0,
+            fd_fraction: 0.0,
+        }
+    }
+
+    pub fn calculate(&mut self, bodies: &[Body]) {
+        const SHELL_FACTOR: f32 = 3.0;
+        const CONTACT_BUFFER: f32 = 0.1;
+
+        let mut li_coord_total = 0usize;
+        let mut an_coord_total = 0usize;
+        let mut li_count = 0usize;
+        let mut anion_count = 0usize;
+
+        let mut cip = 0usize;
+        let mut sip = 0usize;
+        let mut s2ip = 0usize;
+        let mut fd = 0usize;
+
+        for (i, body) in bodies.iter().enumerate() {
+            match body.species {
+                Species::LithiumIon => {
+                    li_count += 1;
+                    let shell = body.radius * SHELL_FACTOR;
+                    let li_solvents = count_solvent_neighbors(bodies, i, shell);
+                    li_coord_total += li_solvents;
+
+                    if let Some((j, dist)) = nearest_body_with_species(bodies, i, Species::ElectrolyteAnion) {
+                        let an_shell = bodies[j].radius * SHELL_FACTOR;
+                        let an_solvents = count_solvent_neighbors(bodies, j, an_shell);
+                        an_coord_total += an_solvents;
+
+                        let contact_cutoff = body.radius + bodies[j].radius + CONTACT_BUFFER;
+                        if dist < contact_cutoff {
+                            cip += 1;
+                        } else if li_solvents >= 4 && an_solvents >= 4 {
+                            s2ip += 1;
+                        } else {
+                            sip += 1;
+                        }
+                    } else {
+                        fd += 1;
+                    }
+                }
+                Species::ElectrolyteAnion => {
+                    anion_count += 1;
+                    let shell = body.radius * SHELL_FACTOR;
+                    let solvents = count_solvent_neighbors(bodies, i, shell);
+                    an_coord_total += solvents;
+                }
+                _ => {}
+            }
+        }
+
+        self.temperature = compute_temperature(bodies);
+        self.avg_li_coordination = if li_count > 0 { li_coord_total as f32 / li_count as f32 } else { 0.0 };
+        self.avg_anion_coordination = if anion_count > 0 { an_coord_total as f32 / anion_count as f32 } else { 0.0 };
+        if li_count > 0 {
+            self.cip_fraction = cip as f32 / li_count as f32;
+            self.sip_fraction = sip as f32 / li_count as f32;
+            self.s2ip_fraction = s2ip as f32 / li_count as f32;
+            self.fd_fraction = fd as f32 / li_count as f32;
+        } else {
+            self.cip_fraction = 0.0;
+            self.sip_fraction = 0.0;
+            self.s2ip_fraction = 0.0;
+            self.fd_fraction = 0.0;
+        }
+    }
+}
+
+fn count_solvent_neighbors(bodies: &[Body], index: usize, radius: f32) -> usize {
+    let pos = bodies[index].pos;
+    bodies
+        .iter()
+        .enumerate()
+        .filter(|(i, b)| {
+            *i != index && matches!(b.species, Species::EC | Species::DMC) && (b.pos - pos).mag() < radius
+        })
+        .count()
+}
+
+fn nearest_body_with_species(bodies: &[Body], index: usize, species: Species) -> Option<(usize, f32)> {
+    let pos = bodies[index].pos;
+    let mut best = None;
+    let mut best_dist = f32::INFINITY;
+    for (i, b) in bodies.iter().enumerate() {
+        if i == index || b.species != species {
+            continue;
+        }
+        let dist = (b.pos - pos).mag();
+        if dist < best_dist {
+            best_dist = dist;
+            best = Some(i);
+        }
+    }
+    best.map(|i| (i, best_dist))
+}
+

--- a/src/diagnostics/solvation.rs
+++ b/src/diagnostics/solvation.rs
@@ -12,6 +12,12 @@ pub struct SolvationDiagnostic {
     pub sip_fraction: f32,
     pub s2ip_fraction: f32,
     pub fd_fraction: f32,
+    
+    // Ion ID lists for visual overlays
+    pub cip_ion_ids: Vec<u64>,
+    pub sip_ion_ids: Vec<u64>,
+    pub s2ip_ion_ids: Vec<u64>,
+    pub fd_ion_ids: Vec<u64>,
 }
 
 impl SolvationDiagnostic {
@@ -24,11 +30,17 @@ impl SolvationDiagnostic {
             sip_fraction: 0.0,
             s2ip_fraction: 0.0,
             fd_fraction: 0.0,
+            
+            // Initialize empty ion ID lists
+            cip_ion_ids: Vec::new(),
+            sip_ion_ids: Vec::new(),
+            s2ip_ion_ids: Vec::new(),
+            fd_ion_ids: Vec::new(),
         }
     }
 
     pub fn calculate(&mut self, bodies: &[Body]) {
-        const SHELL_FACTOR: f32 = 3.0;
+        const SHELL_FACTOR: f32 = 2.0; // Reduced from 3.0 for tighter solvation shell
         const CONTACT_BUFFER: f32 = 0.1;
 
         let mut li_coord_total = 0usize;
@@ -36,10 +48,16 @@ impl SolvationDiagnostic {
         let mut li_count = 0usize;
         let mut anion_count = 0usize;
 
-        let mut cip = 0usize;
-        let mut sip = 0usize;
-        let mut s2ip = 0usize;
-        let mut fd = 0usize;
+        // Clear previous ion ID lists
+        self.cip_ion_ids.clear();
+        self.sip_ion_ids.clear();
+        self.s2ip_ion_ids.clear();
+        self.fd_ion_ids.clear();
+
+        // Get typical solvent radius (average of EC and DMC)
+        let ec_radius = crate::body::Species::EC.radius();
+        let dmc_radius = crate::body::Species::DMC.radius();
+        let avg_solvent_radius = (ec_radius + dmc_radius) / 2.0;
 
         for (i, body) in bodies.iter().enumerate() {
             match body.species {
@@ -50,20 +68,29 @@ impl SolvationDiagnostic {
                     li_coord_total += li_solvents;
 
                     if let Some((j, dist)) = nearest_body_with_species(bodies, i, Species::ElectrolyteAnion) {
-                        let an_shell = bodies[j].radius * SHELL_FACTOR;
-                        let an_solvents = count_solvent_neighbors(bodies, j, an_shell);
-                        an_coord_total += an_solvents;
-
-                        let contact_cutoff = body.radius + bodies[j].radius + CONTACT_BUFFER;
-                        if dist < contact_cutoff {
-                            cip += 1;
-                        } else if li_solvents >= 4 && an_solvents >= 4 {
-                            s2ip += 1;
+                        // Calculate max pairing distance: Li+ radius + 1.5*solvent radius + anion radius
+                        let max_pairing_distance = body.radius + 1.5 * avg_solvent_radius + bodies[j].radius;
+                        
+                        if dist > max_pairing_distance {
+                            // Too far from any anion to be considered paired
+                            self.fd_ion_ids.push(body.id);
                         } else {
-                            sip += 1;
+                            let an_shell = bodies[j].radius * SHELL_FACTOR;
+                            let an_solvents = count_solvent_neighbors(bodies, j, an_shell);
+                            an_coord_total += an_solvents;
+
+                            let contact_cutoff = body.radius + bodies[j].radius + CONTACT_BUFFER;
+                            if dist < contact_cutoff {
+                                self.cip_ion_ids.push(body.id);
+                            } else if li_solvents >= 2 && an_solvents >= 2 {
+                                self.s2ip_ion_ids.push(body.id);
+                            } else {
+                                self.sip_ion_ids.push(body.id);
+                            }
                         }
                     } else {
-                        fd += 1;
+                        // No anions exist in the simulation
+                        self.fd_ion_ids.push(body.id);
                     }
                 }
                 Species::ElectrolyteAnion => {
@@ -80,10 +107,10 @@ impl SolvationDiagnostic {
         self.avg_li_coordination = if li_count > 0 { li_coord_total as f32 / li_count as f32 } else { 0.0 };
         self.avg_anion_coordination = if anion_count > 0 { an_coord_total as f32 / anion_count as f32 } else { 0.0 };
         if li_count > 0 {
-            self.cip_fraction = cip as f32 / li_count as f32;
-            self.sip_fraction = sip as f32 / li_count as f32;
-            self.s2ip_fraction = s2ip as f32 / li_count as f32;
-            self.fd_fraction = fd as f32 / li_count as f32;
+            self.cip_fraction = self.cip_ion_ids.len() as f32 / li_count as f32;
+            self.sip_fraction = self.sip_ion_ids.len() as f32 / li_count as f32;
+            self.s2ip_fraction = self.s2ip_ion_ids.len() as f32 / li_count as f32;
+            self.fd_fraction = self.fd_ion_ids.len() as f32 / li_count as f32;
         } else {
             self.cip_fraction = 0.0;
             self.sip_fraction = 0.0;

--- a/src/renderer/draw/mod.rs
+++ b/src/renderer/draw/mod.rs
@@ -46,6 +46,9 @@ impl super::Renderer {
                     let current_time = *crate::renderer::state::SIM_TIME.lock();
                     diag.calculate_if_needed(&self.bodies, &self.foils, &temp_quadtree, current_time, 1.0);
                 }
+                if let Some(ref mut diag) = self.solvation_diagnostic {
+                    diag.calculate(&self.bodies);
+                }
             }
             if let Some(body) = self.confirmed_bodies.take() {
                 self.bodies.push(body.clone());

--- a/src/renderer/draw/mod.rs
+++ b/src/renderer/draw/mod.rs
@@ -149,6 +149,61 @@ impl super::Renderer {
                 }
             }
 
+            // --- Ion Classification Overlay ---
+            if let Some(ref solvation_diag) = self.solvation_diagnostic {
+                // Draw CIP ions with red circles
+                if self.show_cip_ions {
+                    for &ion_id in &solvation_diag.cip_ion_ids {
+                        if let Some(body) = self.bodies.iter().find(|b| b.id == ion_id) {
+                            ctx.draw_circle(
+                                body.pos,
+                                body.radius * 2.0,
+                                [255, 0, 0, 80], // red with transparency for outline effect
+                            );
+                        }
+                    }
+                }
+
+                // Draw SIP ions with orange circles
+                if self.show_sip_ions {
+                    for &ion_id in &solvation_diag.sip_ion_ids {
+                        if let Some(body) = self.bodies.iter().find(|b| b.id == ion_id) {
+                            ctx.draw_circle(
+                                body.pos,
+                                body.radius * 2.0,
+                                [255, 165, 0, 80], // orange with transparency
+                            );
+                        }
+                    }
+                }
+
+                // Draw S2IP ions with yellow circles
+                if self.show_s2ip_ions {
+                    for &ion_id in &solvation_diag.s2ip_ion_ids {
+                        if let Some(body) = self.bodies.iter().find(|b| b.id == ion_id) {
+                            ctx.draw_circle(
+                                body.pos,
+                                body.radius * 2.0,
+                                [255, 255, 0, 80], // yellow with transparency
+                            );
+                        }
+                    }
+                }
+
+                // Draw FD (free/dissociated) ions with blue circles
+                if self.show_fd_ions {
+                    for &ion_id in &solvation_diag.fd_ion_ids {
+                        if let Some(body) = self.bodies.iter().find(|b| b.id == ion_id) {
+                            ctx.draw_circle(
+                                body.pos,
+                                body.radius * 2.0,
+                                [0, 0, 255, 80], // blue with transparency
+                            );
+                        }
+                    }
+                }
+            }
+
             if let Some(body) = &self.confirmed_bodies {
                 ctx.draw_circle(body.pos, body.radius, [0xff; 4]);
                 ctx.draw_line(body.pos, body.pos + body.vel, [0xff; 4]);

--- a/src/renderer/gui/diagnostics_tab.rs
+++ b/src/renderer/gui/diagnostics_tab.rs
@@ -90,6 +90,35 @@ impl super::super::Renderer {
 
         ui.separator();
 
+        // Solvation diagnostic
+        ui.group(|ui| {
+            ui.label("🧪 Solvation State");
+            if let Some(diag) = &self.solvation_diagnostic {
+                ui.horizontal(|ui| {
+                    ui.label("Temperature:");
+                    ui.label(format!("{:.3}", diag.temperature));
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Avg Li coordination:");
+                    ui.label(format!("{:.2}", diag.avg_li_coordination));
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Avg anion coordination:");
+                    ui.label(format!("{:.2}", diag.avg_anion_coordination));
+                });
+                ui.separator();
+                ui.label("Solvation distribution:");
+                ui.label(format!(
+                    "CIP: {:.3}\nSIP: {:.3}\nS2IP: {:.3}\nFD: {:.3}",
+                    diag.cip_fraction, diag.sip_fraction, diag.s2ip_fraction, diag.fd_fraction
+                ));
+            } else {
+                ui.label("❌ No diagnostic data available.");
+            }
+        });
+
+        ui.separator();
+
         // Additional diagnostic information
         ui.group(|ui| {
             ui.label("📈 Simulation Statistics");

--- a/src/renderer/gui/diagnostics_tab.rs
+++ b/src/renderer/gui/diagnostics_tab.rs
@@ -112,6 +112,17 @@ impl super::super::Renderer {
                     "CIP: {:.3}\nSIP: {:.3}\nS2IP: {:.3}\nFD: {:.3}",
                     diag.cip_fraction, diag.sip_fraction, diag.s2ip_fraction, diag.fd_fraction
                 ));
+                
+                ui.separator();
+                ui.label("🔍 Visual Overlays:");
+                ui.horizontal(|ui| {
+                    ui.checkbox(&mut self.show_cip_ions, "Show CIP");
+                    ui.checkbox(&mut self.show_sip_ions, "Show SIP");
+                });
+                ui.horizontal(|ui| {
+                    ui.checkbox(&mut self.show_s2ip_ions, "Show S2IP");
+                    ui.checkbox(&mut self.show_fd_ions, "Show FD");
+                });
             } else {
                 ui.label("❌ No diagnostic data available.");
             }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -110,6 +110,12 @@ pub struct Renderer {
     pub foil_electron_fraction_diagnostic: Option<FoilElectronFractionDiagnostic>,
     pub solvation_diagnostic: Option<crate::diagnostics::SolvationDiagnostic>,
     
+    // Solvation visualization flags
+    pub show_cip_ions: bool,
+    pub show_sip_ions: bool,
+    pub show_s2ip_ions: bool,
+    pub show_fd_ions: bool,
+    
     // Screen capture functionality
     pub screen_capture_enabled: bool,
     pub capture_interval: f32,  // seconds between captures
@@ -183,6 +189,12 @@ impl quarkstrom::Renderer for Renderer {
             transference_number_diagnostic: Some(TransferenceNumberDiagnostic::new()),
             foil_electron_fraction_diagnostic: Some(FoilElectronFractionDiagnostic::new()),
             solvation_diagnostic: Some(crate::diagnostics::SolvationDiagnostic::new()),
+            
+            // Solvation visualization flags - default to false
+            show_cip_ions: false,
+            show_sip_ions: false,
+            show_s2ip_ions: false,
+            show_fd_ions: false,
             
             // Screen capture defaults
             screen_capture_enabled: false,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -108,6 +108,7 @@ pub struct Renderer {
     pub current_tab: GuiTab,
     pub transference_number_diagnostic: Option<TransferenceNumberDiagnostic>,
     pub foil_electron_fraction_diagnostic: Option<FoilElectronFractionDiagnostic>,
+    pub solvation_diagnostic: Option<crate::diagnostics::SolvationDiagnostic>,
     
     // Screen capture functionality
     pub screen_capture_enabled: bool,
@@ -181,6 +182,7 @@ impl quarkstrom::Renderer for Renderer {
             current_tab: GuiTab::default(), // Default to Simulation tab
             transference_number_diagnostic: Some(TransferenceNumberDiagnostic::new()),
             foil_electron_fraction_diagnostic: Some(FoilElectronFractionDiagnostic::new()),
+            solvation_diagnostic: Some(crate::diagnostics::SolvationDiagnostic::new()),
             
             // Screen capture defaults
             screen_capture_enabled: false,


### PR DESCRIPTION
## Summary
- compute coordination numbers and solvation state distribution
- display solvation information in diagnostics tab

## Testing
- `cargo check` *(fails: failed to load `quarkstrom` dependency due to network)*

------
https://chatgpt.com/codex/tasks/task_b_68894c6dda848332b9c9ed2d3a83cc5e