### PR TITLE
Optimize electron hopping neighbor selection

### DIFF
--- a/src/quadtree/quadtree.rs
+++ b/src/quadtree/quadtree.rs
@@ -308,9 +308,9 @@ impl Quadtree {
     }
 
     /// Find indices of bodies within `cutoff` distance of body at index `i` (excluding `i` itself)
-    pub fn find_neighbors_within(&self, bodies: &[Body], i: usize, cutoff: f32) -> Vec<usize> {
+    pub fn find_neighbors_within_into(&self, bodies: &[Body], i: usize, cutoff: f32, out: &mut Vec<usize>) {
         profile_scope!("quadtree_neighbors");
-        let mut neighbors = Vec::new();
+        out.clear();
         let pos = bodies[i].pos;
         let cutoff_sq = cutoff * cutoff;
 
@@ -336,7 +336,7 @@ impl Quadtree {
             if node.is_leaf() {
                 for idx in node.bodies.clone() {
                     if idx != i && (bodies[idx].pos - pos).mag_sq() < cutoff_sq {
-                        neighbors.push(idx);
+                        out.push(idx);
                     }
                 }
             } else {
@@ -345,6 +345,11 @@ impl Quadtree {
                 }
             }
         }
+    }
+
+    pub fn find_neighbors_within(&self, bodies: &[Body], i: usize, cutoff: f32) -> Vec<usize> {
+        let mut neighbors = Vec::new();
+        self.find_neighbors_within_into(bodies, i, cutoff, &mut neighbors);
         neighbors
     }
 


### PR DESCRIPTION
## Summary
- Avoid allocating and filtering a temporary vector when selecting electron hop targets.
- Add quadtree helper to fill a reusable neighbor buffer without allocation.

## Testing
- `cargo check` *(fails: failed to download crates; 403 CONNECT tunnel failed)*
- `cargo run --features profiling` *(fails: failed to download crates; 403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_b_68956da733d48332a334b1fe94d129df