### PR TITLE
Add electron affinity gating for electron hopping

### DIFF
--- a/src/body/types.rs
+++ b/src/body/types.rs
@@ -269,6 +269,15 @@ impl Species {
         self.props().repulsion_cutoff
     }
 
+    pub fn electron_affinity_eV(&self) -> f32 {
+        self.props().electron_affinity_eV
+    }
+
+    /// Electron affinity converted to simulation energy units.
+    pub fn electron_affinity_energy(&self) -> f32 {
+        self.electron_affinity_eV() * crate::units::EV_TO_SIM as f32
+    }
+
     /// Surface affinity - how strongly this species is attracted to electrode surfaces
     pub fn surface_affinity(&self) -> f32 {
         use Species::*;

--- a/src/species.rs
+++ b/src/species.rs
@@ -18,6 +18,8 @@ pub struct SpeciesProps {
     pub lj_cutoff: f32,
     pub polar_offset: f32,
     pub polar_charge: f32,
+    /// Electron affinity or site energy in electronvolts (eV)
+    pub electron_affinity_eV: f32,
     pub enable_repulsion: bool,
     pub repulsion_strength: f32,
     pub repulsion_cutoff: f32,
@@ -39,6 +41,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            electron_affinity_eV: 5.391, // Approximate Li+ electron affinity
             enable_repulsion: false,
             repulsion_strength: 5.0,
             repulsion_cutoff: 2.0,
@@ -57,6 +60,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR_METAL,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            electron_affinity_eV: 2.93, // Lithium metal work function (approx.)
             enable_repulsion: false,
             repulsion_strength: 5.0,
             repulsion_cutoff: 2.0,
@@ -75,6 +79,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR_METAL,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            electron_affinity_eV: 2.93,
             enable_repulsion: false,
             repulsion_strength: 5.0,
             repulsion_cutoff: 2.0,
@@ -93,6 +98,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.3,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            electron_affinity_eV: 0.0,
             enable_repulsion: false,
             repulsion_strength: 5.0,
             repulsion_cutoff: 2.0,
@@ -111,6 +117,7 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR_EC,
             polar_charge: crate::config::POLAR_CHARGE_EC,
+            electron_affinity_eV: 0.0,
             enable_repulsion: true,
             repulsion_strength: 5.0,  // Reduced from 100.0 - represents osmotic pressure
             repulsion_cutoff: 6.0,    // Reduced from 11.0 - shorter range interaction
@@ -129,8 +136,9 @@ pub static SPECIES_PROPERTIES: Lazy<HashMap<Species, SpeciesProps>> = Lazy::new(
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: crate::config::ELECTRON_DRIFT_RADIUS_FACTOR_DMC,
             polar_charge: crate::config::POLAR_CHARGE_DMC,
+            electron_affinity_eV: 0.0,
             enable_repulsion: true,
-            repulsion_strength: 5.0,  // Reduced from 100.0 - represents osmotic pressure  
+            repulsion_strength: 5.0,  // Reduced from 100.0 - represents osmotic pressure
             repulsion_cutoff: 6.0,    // Reduced from 11.0 - shorter range interaction
         },
     );
@@ -190,6 +198,7 @@ pub fn get_species_props(species: Species) -> SpeciesProps {
             lj_cutoff: crate::config::LJ_FORCE_CUTOFF,
             polar_offset: 0.0,
             polar_charge: crate::config::POLAR_CHARGE_DEFAULT,
+            electron_affinity_eV: 0.0,
             enable_repulsion: false,
             repulsion_strength: 5.0,
             repulsion_cutoff: 2.0,


### PR DESCRIPTION
## Summary
- add per-species electron affinity values including lithium metal and lithium ion defaults
- expose a quadtree helper to evaluate electrostatic potential at arbitrary points
- gate electron hopping moves using site energy differences so hops favor lower energy destinations

## Testing
- cargo check *(fails: missing local dependency `quarkstrom`)*

------
https://chatgpt.com/codex/tasks/task_b_68c86131dc70833281efeba5b3f4e404