### PR TITLE
Add switch charging controls and scheduler

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,10 +33,14 @@ pub fn run() {
     let (tx, rx) = channel();
     *SIM_COMMAND_SENDER.lock() = Some(tx);
 
-    let simulation = Simulation::new();
+    let (ui_handles, sim_handles) = crate::switch_charging::create_channels();
+    crate::switch_charging::install_ui_handles(ui_handles);
+
+    let mut simulation = Simulation::new();
+    simulation.set_switch_status_sender(sim_handles.status_tx.clone());
 
     std::thread::spawn(move || {
-        simulation_loop::run_simulation_loop(rx, simulation);
+        simulation_loop::run_simulation_loop(rx, simulation, sim_handles);
     });
 
     quarkstrom::run::<Renderer>(config);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod init_config;
 pub mod diagnostics;
 pub mod commands;
 pub mod scenario;
+pub mod switch_charging;
 
 pub mod app;
 

--- a/src/renderer/gui/mod.rs
+++ b/src/renderer/gui/mod.rs
@@ -5,6 +5,7 @@ use crate::body::Species;
 use crate::config::IsolineFieldMode;
 use crate::profile_scope;
 use crate::renderer::Body;
+use crate::switch_charging;
 use quarkstrom::egui::{self, Vec2 as EVec2};
 use ultraviolet::Vec2;
 
@@ -107,6 +108,11 @@ impl super::Renderer {
                         );
                         ui.selectable_value(
                             &mut self.current_tab,
+                            super::GuiTab::SwitchCharging,
+                            "🔁 Switch Charging",
+                        );
+                        ui.selectable_value(
+                            &mut self.current_tab,
                             super::GuiTab::SoftDynamics,
                             "🔧 Soft Dynamics",
                         );
@@ -114,6 +120,13 @@ impl super::Renderer {
                 });
 
                 ui.separator();
+
+                self.switch_ui_state
+                    .sync_sim_dt(*crate::renderer::state::TIMESTEP.lock());
+                self.switch_ui_state.update_available_foils(&self.foils);
+                let selected_for_assignment = self.selected_foil_ids.last().copied();
+                self.switch_ui_state
+                    .consume_selected_foil(selected_for_assignment);
 
                 // Show content based on selected tab
                 egui::ScrollArea::vertical()
@@ -125,6 +138,9 @@ impl super::Renderer {
                         super::GuiTab::Physics => self.show_physics_tab(ui),
                         super::GuiTab::Scenario => self.show_scenario_tab(ui),
                         super::GuiTab::Foils => self.show_foils_tab(ui),
+                        super::GuiTab::SwitchCharging => {
+                            switch_charging::ui_switch_charging(ui, &mut self.switch_ui_state)
+                        }
                         super::GuiTab::Analysis => self.show_analysis_tab(ui),
                         super::GuiTab::Debug => self.show_debug_tab(ui),
                         super::GuiTab::Diagnostics => self.show_diagnostics_tab(ui),

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -10,6 +10,7 @@ use crate::diagnostics::{FoilElectronFractionDiagnostic, TransferenceNumberDiagn
 use crate::plotting::{PlotType, PlottingSystem, Quantity, SamplingMode};
 use crate::quadtree::Node;
 use crate::renderer::state::{SimCommand, SIM_COMMAND_SENDER};
+use crate::switch_charging;
 use quarkstrom::egui::{self, Color32, Pos2, Vec2 as EVec2};
 use quarkstrom::winit_input_helper::WinitInputHelper;
 use std::collections::HashMap;
@@ -77,6 +78,7 @@ pub enum GuiTab {
     Physics,
     Scenario,
     Foils,
+    SwitchCharging,
     Analysis,
     Debug,
     Diagnostics,
@@ -110,6 +112,7 @@ pub struct Renderer {
     selected_foil_ids: Vec<u64>,
     selected_particle_ids: Vec<u64>,
     selected_pid_foil_id: Option<u64>, // For PID graph foil selection
+    switch_ui_state: switch_charging::SwitchUiState,
     sim_config: SimConfig,
     /// Local copy of the simulation frame for time-based visualizations
     frame: usize,
@@ -166,7 +169,7 @@ pub struct Renderer {
     pub show_sip_ions: bool,
     pub show_s2ip_ions: bool,
     pub show_fd_ions: bool,
-    
+
     // 2D Domain Density Calculation - Species Selection
     pub density_calc_lithium_ion: bool,
     pub density_calc_lithium_metal: bool,
@@ -174,7 +177,7 @@ pub struct Renderer {
     pub density_calc_electrolyte_anion: bool,
     pub density_calc_ec: bool,
     pub density_calc_dmc: bool,
-    
+
     // View mode toggle
     pub side_view_mode: bool, // false = X-Y (top-down), true = X-Z (side view)
 
@@ -257,6 +260,7 @@ impl quarkstrom::Renderer for Renderer {
             selected_foil_ids: Vec::new(),
             selected_particle_ids: Vec::new(),
             selected_pid_foil_id: None, // Initialize PID graph foil selection to None
+            switch_ui_state: switch_charging::SwitchUiState::new(),
             sim_config: crate::config::LJ_CONFIG.lock().clone(),
             frame: 0,
             playback_cursor: 0,

--- a/src/switch_charging/mod.rs
+++ b/src/switch_charging/mod.rs
@@ -1,0 +1,979 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::Mutex;
+
+use crossbeam::channel::{self, Receiver, Sender, TryRecvError};
+use once_cell::sync::Lazy;
+use quarkstrom::egui;
+use serde::{Deserialize, Serialize};
+
+use crate::body::foil::{ChargingMode, Foil, OverpotentialController};
+
+pub type FoilId = u64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Role {
+    #[serde(rename = "+A")]
+    PosA,
+    #[serde(rename = "+B")]
+    PosB,
+    #[serde(rename = "-A")]
+    NegA,
+    #[serde(rename = "-B")]
+    NegB,
+}
+
+impl Role {
+    pub const ALL: [Role; 4] = [Role::PosA, Role::PosB, Role::NegA, Role::NegB];
+
+    pub fn display(&self) -> &'static str {
+        match self {
+            Role::PosA => "+A",
+            Role::PosB => "+B",
+            Role::NegA => "-A",
+            Role::NegB => "-B",
+        }
+    }
+
+    pub fn description(&self) -> &'static str {
+        match self {
+            Role::PosA => "Acting cathode A",
+            Role::PosB => "Acting cathode B",
+            Role::NegA => "Acting anode A",
+            Role::NegB => "Acting anode B",
+        }
+    }
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Mode {
+    Current,
+    Overpotential,
+}
+
+impl Default for Mode {
+    fn default() -> Self {
+        Mode::Current
+    }
+}
+
+impl Mode {
+    pub fn tooltip(&self) -> &'static str {
+        match self {
+            Mode::Current => "Direct current control in electrons/fs",
+            Mode::Overpotential => "PID-controlled overpotential target",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct StepSetpoint {
+    pub mode: Mode,
+    pub value: f64,
+}
+
+impl Default for StepSetpoint {
+    fn default() -> Self {
+        Self {
+            mode: Mode::Current,
+            value: 0.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SwitchChargingConfig {
+    pub role_to_foil: HashMap<Role, FoilId>,
+    pub sim_dt_s: f64,
+    pub switch_rate_hz: f64,
+    pub delta_steps: u32,
+    pub step_setpoints: HashMap<u8, StepSetpoint>,
+}
+
+impl Default for SwitchChargingConfig {
+    fn default() -> Self {
+        let mut cfg = Self {
+            role_to_foil: HashMap::new(),
+            sim_dt_s: default_sim_dt_s(),
+            switch_rate_hz: 1.0,
+            delta_steps: 1,
+            step_setpoints: HashMap::new(),
+        };
+        cfg.ensure_all_steps();
+        cfg.recompute_from_steps();
+        cfg
+    }
+}
+
+impl SwitchChargingConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.sim_dt_s.is_finite() || self.sim_dt_s <= 0.0 {
+            return Err("Simulation timestep must be a positive finite value".into());
+        }
+        if !self.switch_rate_hz.is_finite() || self.switch_rate_hz <= 0.0 {
+            return Err("Switching frequency must be positive".into());
+        }
+        if self.delta_steps == 0 {
+            return Err("Switch dwell Δt must be at least one simulation step".into());
+        }
+
+        for role in Role::ALL.iter() {
+            if !self.role_to_foil.contains_key(role) {
+                return Err(format!("Missing foil assignment for role {}", role));
+            }
+        }
+
+        let mut seen = HashSet::new();
+        for (role, foil_id) in &self.role_to_foil {
+            if !seen.insert(*foil_id) {
+                return Err(format!(
+                    "Foil {foil_id} has been assigned to multiple roles (including {role})"
+                ));
+            }
+        }
+
+        for step in 0u8..4u8 {
+            let Some(setpoint) = self.step_setpoints.get(&step) else {
+                return Err(format!("Missing setpoint for step {}", step + 1));
+            };
+            if !setpoint.value.is_finite() {
+                return Err(format!("Step {} setpoint must be finite", step + 1));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn recompute_from_hz(&mut self) {
+        if self.switch_rate_hz.is_finite() && self.switch_rate_hz > 0.0 && self.sim_dt_s > 0.0 {
+            let steps = (1.0 / (self.switch_rate_hz * self.sim_dt_s)).round();
+            self.delta_steps = steps.max(1.0) as u32;
+        }
+    }
+
+    pub fn recompute_from_steps(&mut self) {
+        if self.delta_steps > 0 && self.sim_dt_s > 0.0 {
+            self.switch_rate_hz = 1.0 / (self.delta_steps as f64 * self.sim_dt_s);
+        }
+    }
+
+    pub fn cycle_period_s(&self) -> f64 {
+        4.0 * self.delta_steps as f64 * self.sim_dt_s
+    }
+
+    pub fn foil_for_role(&self, role: Role) -> Option<FoilId> {
+        self.role_to_foil.get(&role).copied()
+    }
+
+    pub fn ensure_all_steps(&mut self) {
+        for step in 0..4u8 {
+            self.step_setpoints
+                .entry(step)
+                .or_insert_with(StepSetpoint::default);
+        }
+    }
+}
+
+pub fn roles_for_step(step_index: u8) -> (Role, Role) {
+    match step_index % 4 {
+        0 => (Role::PosA, Role::NegA),
+        1 => (Role::PosB, Role::NegB),
+        2 => (Role::PosB, Role::NegA),
+        _ => (Role::PosA, Role::NegB),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RunState {
+    Idle,
+    Running,
+    Paused,
+}
+
+impl Default for RunState {
+    fn default() -> Self {
+        RunState::Idle
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SwitchControl {
+    Start,
+    Pause,
+    Stop,
+    UpdateConfig(SwitchChargingConfig),
+}
+
+#[derive(Clone, Debug)]
+pub enum SwitchStatus {
+    RunState(RunState),
+    ActiveStep {
+        step_index: u8,
+        dwell_remaining: u32,
+    },
+    ConfigApplied(SwitchChargingConfig),
+    ValidationFailed(String),
+}
+
+pub type ControlSender = Sender<SwitchControl>;
+pub type ControlReceiver = Receiver<SwitchControl>;
+pub type StatusSender = Sender<SwitchStatus>;
+pub type StatusReceiver = Receiver<SwitchStatus>;
+
+#[derive(Debug)]
+pub struct UiHandles {
+    pub control_tx: ControlSender,
+    pub status_rx: StatusReceiver,
+}
+
+#[derive(Debug)]
+pub struct SimHandles {
+    pub control_rx: ControlReceiver,
+    pub status_tx: StatusSender,
+}
+
+pub fn create_channels() -> (UiHandles, SimHandles) {
+    let (control_tx, control_rx) = channel::unbounded();
+    let (status_tx, status_rx) = channel::unbounded();
+    (
+        UiHandles {
+            control_tx: control_tx.clone(),
+            status_rx,
+        },
+        SimHandles {
+            control_rx,
+            status_tx,
+        },
+    )
+}
+
+static UI_HANDLES: Lazy<Mutex<Option<UiHandles>>> = Lazy::new(|| Mutex::new(None));
+
+pub fn install_ui_handles(handles: UiHandles) {
+    *UI_HANDLES.lock().unwrap() = Some(handles);
+}
+
+pub fn take_ui_handles() -> Option<UiHandles> {
+    UI_HANDLES.lock().unwrap().take()
+}
+
+#[derive(Clone, Debug)]
+pub struct SwitchScheduler {
+    pub current_step: u8,
+    pub steps_left: u32,
+    pub armed: bool,
+}
+
+impl Default for SwitchScheduler {
+    fn default() -> Self {
+        Self {
+            current_step: 0,
+            steps_left: 0,
+            armed: false,
+        }
+    }
+}
+
+impl SwitchScheduler {
+    pub fn start(&mut self, cfg: &SwitchChargingConfig) {
+        self.armed = true;
+        self.current_step = 0;
+        self.steps_left = cfg.delta_steps.max(1);
+    }
+
+    pub fn pause(&mut self) {
+        self.armed = false;
+    }
+
+    pub fn stop(&mut self) {
+        self.armed = false;
+        self.current_step = 0;
+        self.steps_left = 0;
+    }
+
+    pub fn sync_with_config(&mut self, cfg: &SwitchChargingConfig) {
+        if cfg.delta_steps == 0 {
+            self.steps_left = 0;
+            self.current_step = 0;
+            self.armed = false;
+            return;
+        }
+        if self.steps_left == 0 && self.armed {
+            self.steps_left = cfg.delta_steps;
+        } else if self.steps_left > cfg.delta_steps {
+            self.steps_left = cfg.delta_steps;
+        }
+    }
+
+    pub fn on_tick(
+        &mut self,
+        cfg: &SwitchChargingConfig,
+    ) -> Option<((FoilId, FoilId), StepSetpoint)> {
+        if !self.armed || cfg.delta_steps == 0 {
+            return None;
+        }
+        if self.steps_left == 0 {
+            self.current_step = (self.current_step + 1) % 4;
+            self.steps_left = cfg.delta_steps;
+        }
+
+        self.steps_left = self.steps_left.saturating_sub(1);
+        let step = self.current_step;
+        let (positive, negative) = roles_for_step(step);
+        let pos_id = cfg.foil_for_role(positive)?;
+        let neg_id = cfg.foil_for_role(negative)?;
+        let setpoint = cfg.step_setpoints.get(&step)?.clone();
+
+        Some(((pos_id, neg_id), setpoint))
+    }
+
+    pub fn current_step(&self) -> u8 {
+        self.current_step
+    }
+
+    pub fn dwell_remaining(&self) -> u32 {
+        self.steps_left
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FoilStateSnapshot {
+    charging_mode: ChargingMode,
+    dc_current: f32,
+    ac_current: f32,
+    switch_hz: f32,
+    overpotential_controller: Option<OverpotentialController>,
+    slave_overpotential_current: f32,
+}
+
+impl FoilStateSnapshot {
+    pub fn from_foil(foil: &Foil) -> Self {
+        Self {
+            charging_mode: foil.charging_mode,
+            dc_current: foil.dc_current,
+            ac_current: foil.ac_current,
+            switch_hz: foil.switch_hz,
+            overpotential_controller: foil.overpotential_controller.clone(),
+            slave_overpotential_current: foil.slave_overpotential_current,
+        }
+    }
+
+    pub fn apply(&self, foil: &mut Foil) {
+        foil.charging_mode = self.charging_mode;
+        foil.dc_current = self.dc_current;
+        foil.ac_current = self.ac_current;
+        foil.switch_hz = self.switch_hz;
+        foil.overpotential_controller = self.overpotential_controller.clone();
+        foil.slave_overpotential_current = self.slave_overpotential_current;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct FoilDescriptor {
+    id: FoilId,
+    label: String,
+}
+
+#[derive(Debug)]
+pub struct SwitchUiState {
+    pub config: SwitchChargingConfig,
+    pub validation_error: Option<String>,
+    pub run_state: RunState,
+    pub pending_role: Option<Role>,
+    pub last_step_status: Option<(u8, u32)>,
+    available_foils: Vec<FoilDescriptor>,
+    control_tx: Option<ControlSender>,
+    status_rx: Option<StatusReceiver>,
+    last_selected_foil: Option<FoilId>,
+    pub json_buffer: String,
+    pub status_message: Option<String>,
+    pub import_error: Option<String>,
+    config_dirty: bool,
+}
+
+impl Default for SwitchUiState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SwitchUiState {
+    pub fn new() -> Self {
+        let handles = take_ui_handles();
+        let (control_tx, status_rx) = if let Some(handles) = handles {
+            (Some(handles.control_tx), Some(handles.status_rx))
+        } else {
+            let (ui_handles, _) = create_channels();
+            (Some(ui_handles.control_tx), Some(ui_handles.status_rx))
+        };
+
+        let mut state = Self {
+            config: SwitchChargingConfig::default(),
+            validation_error: None,
+            run_state: RunState::Idle,
+            pending_role: None,
+            last_step_status: None,
+            available_foils: Vec::new(),
+            control_tx,
+            status_rx,
+            last_selected_foil: None,
+            json_buffer: String::new(),
+            status_message: None,
+            import_error: None,
+            config_dirty: false,
+        };
+        state.update_validation();
+        state
+    }
+
+    pub fn sync_sim_dt(&mut self, dt_fs: f32) {
+        let dt_s = (dt_fs as f64) * 1e-15;
+        if dt_s.is_finite() && dt_s > 0.0 && (dt_s - self.config.sim_dt_s).abs() > f64::EPSILON {
+            self.config.sim_dt_s = dt_s;
+            self.config.recompute_from_steps();
+            self.update_validation();
+        }
+    }
+
+    pub fn update_available_foils(&mut self, foils: &[Foil]) {
+        self.available_foils = foils
+            .iter()
+            .map(|foil| FoilDescriptor {
+                id: foil.id,
+                label: format!("Foil {} ({} particles)", foil.id, foil.body_ids.len()),
+            })
+            .collect();
+        self.available_foils.sort_by_key(|entry| entry.id);
+    }
+
+    pub fn consume_selected_foil(&mut self, selected: Option<FoilId>) {
+        if let Some(role) = self.pending_role {
+            if let Some(foil_id) = selected {
+                if Some(foil_id) != self.last_selected_foil {
+                    self.assign_role(role, foil_id);
+                    self.pending_role = None;
+                    self.status_message = Some(format!("Assigned foil {foil_id} to role {role}"));
+                }
+            }
+        }
+        self.last_selected_foil = selected;
+    }
+
+    pub fn poll_status(&mut self) {
+        let Some(rx) = &self.status_rx else {
+            return;
+        };
+        loop {
+            match rx.try_recv() {
+                Ok(SwitchStatus::RunState(state)) => {
+                    self.run_state = state;
+                    if matches!(state, RunState::Idle) {
+                        self.pending_role = None;
+                    }
+                }
+                Ok(SwitchStatus::ActiveStep {
+                    step_index,
+                    dwell_remaining,
+                }) => {
+                    self.last_step_status = Some((step_index, dwell_remaining));
+                }
+                Ok(SwitchStatus::ConfigApplied(cfg)) => {
+                    self.config = cfg;
+                    self.config.ensure_all_steps();
+                    self.config_dirty = false;
+                    self.update_validation();
+                    self.status_message = Some("Configuration applied to simulation".into());
+                }
+                Ok(SwitchStatus::ValidationFailed(message)) => {
+                    self.validation_error = Some(message);
+                    self.config_dirty = true;
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    self.status_rx = None;
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn start(&mut self) {
+        if self.validation_error.is_some() {
+            return;
+        }
+        if self.config_dirty {
+            self.send_update();
+        }
+        self.send_control(SwitchControl::Start);
+        self.run_state = RunState::Running;
+        self.status_message = Some("Switch charging running".into());
+    }
+
+    pub fn pause(&mut self) {
+        self.send_control(SwitchControl::Pause);
+        self.run_state = RunState::Paused;
+        self.status_message = Some("Switch charging paused".into());
+    }
+
+    pub fn stop(&mut self) {
+        self.send_control(SwitchControl::Stop);
+        self.run_state = RunState::Idle;
+        self.last_step_status = None;
+        self.status_message = Some("Switch charging stopped".into());
+    }
+
+    pub fn send_update(&mut self) {
+        let mut cfg = self.config.clone();
+        cfg.ensure_all_steps();
+        self.send_control(SwitchControl::UpdateConfig(cfg));
+        self.config_dirty = false;
+    }
+
+    fn assign_role(&mut self, role: Role, foil_id: FoilId) {
+        self.ensure_paused_for_edit();
+        self.config.role_to_foil.insert(role, foil_id);
+        self.config_dirty = true;
+        self.update_validation();
+    }
+
+    fn ensure_paused_for_edit(&mut self) {
+        if self.run_state == RunState::Running {
+            self.pause();
+        }
+    }
+
+    pub fn remove_role(&mut self, role: Role) {
+        self.ensure_paused_for_edit();
+        self.config.role_to_foil.remove(&role);
+        self.config_dirty = true;
+        self.update_validation();
+    }
+
+    pub fn edit_step(&mut self, step: u8, new_setpoint: StepSetpoint) {
+        let changed = self
+            .config
+            .step_setpoints
+            .get(&step)
+            .map(|current| current != &new_setpoint)
+            .unwrap_or(true);
+        if changed {
+            self.config.step_setpoints.insert(step, new_setpoint);
+            self.config_dirty = true;
+            self.update_validation();
+        }
+    }
+
+    pub fn set_switch_rate_hz(&mut self, hz: f64) {
+        let hz = hz.max(0.0);
+        if (self.config.switch_rate_hz - hz).abs() > f64::EPSILON {
+            self.config.switch_rate_hz = hz;
+            self.config.recompute_from_hz();
+            self.config_dirty = true;
+            self.update_validation();
+        }
+    }
+
+    pub fn set_delta_steps(&mut self, steps: u32) {
+        let steps = steps.max(1);
+        if self.config.delta_steps != steps {
+            self.config.delta_steps = steps;
+            self.config.recompute_from_steps();
+            self.config_dirty = true;
+            self.update_validation();
+        }
+    }
+
+    pub fn assigned_label(&self, role: Role) -> Option<String> {
+        let foil_id = self.config.role_to_foil.get(&role)?;
+        let label = self
+            .available_foils
+            .iter()
+            .find(|entry| &entry.id == foil_id)
+            .map(|entry| entry.label.clone())
+            .unwrap_or_else(|| format!("Foil {foil_id}"));
+        Some(label)
+    }
+
+    fn send_control(&self, msg: SwitchControl) {
+        if let Some(tx) = &self.control_tx {
+            let _ = tx.send(msg);
+        }
+    }
+
+    fn update_validation(&mut self) {
+        self.validation_error = self.config.validate().err();
+    }
+}
+
+pub fn ui_switch_charging(ui: &mut egui::Ui, state: &mut SwitchUiState) {
+    state.poll_status();
+
+    ui.heading("🔀 Switch Charging");
+
+    ui.horizontal(|ui| {
+        ui.label("Runtime state:");
+        let state_label = match state.run_state {
+            RunState::Idle => "Idle",
+            RunState::Running => "Running",
+            RunState::Paused => "Paused",
+        };
+        ui.strong(state_label);
+        if let Some((step, dwell)) = state.last_step_status {
+            let (pos, neg) = roles_for_step(step);
+            ui.separator();
+            ui.label(format!(
+                "Step {} ({} → {}) | dwell remaining: {}",
+                step + 1,
+                pos.display(),
+                neg.display(),
+                dwell
+            ));
+        }
+    });
+
+    if let Some(msg) = &state.status_message {
+        ui.colored_label(egui::Color32::LIGHT_BLUE, msg);
+    }
+
+    if let Some(err) = &state.validation_error {
+        ui.colored_label(egui::Color32::LIGHT_RED, format!("⚠️ {err}"));
+    } else {
+        ui.colored_label(egui::Color32::LIGHT_GREEN, "Configuration valid");
+    }
+
+    ui.separator();
+
+    ui.group(|ui| {
+        ui.label("Electrode Assignments");
+        egui::Grid::new("switch-roles-grid")
+            .num_columns(2)
+            .spacing([16.0, 8.0])
+            .show(ui, |ui| {
+                for role in Role::ALL.iter() {
+                    ui.label(format!("{}", role.description()));
+                    ui.horizontal(|ui| {
+                        if ui.button(format!("Assign {}", role.display())).clicked() {
+                            state.pending_role = Some(*role);
+                            state.status_message =
+                                Some(format!("Select a foil in the viewport for role {}", role));
+                        }
+                        if let Some(label) = state.assigned_label(*role) {
+                            ui.label(label);
+                        } else {
+                            ui.label("(unassigned)");
+                        }
+                        if ui.button("Clear").clicked() {
+                            state.remove_role(*role);
+                        }
+                    });
+                    ui.end_row();
+                }
+            });
+
+        if let Some(role) = state.pending_role {
+            ui.colored_label(
+                egui::Color32::YELLOW,
+                format!("Click a foil to assign role {}", role.display()),
+            );
+        }
+
+        ui.horizontal_wrapped(|ui| {
+            ui.label("Available foils:");
+            if state.available_foils.is_empty() {
+                ui.label("None detected");
+            } else {
+                for entry in &state.available_foils {
+                    ui.label(format!("{}", entry.label));
+                }
+            }
+        });
+    });
+
+    ui.separator();
+
+    ui.group(|ui| {
+        ui.label("Switching Rate");
+        let mut hz = state.config.switch_rate_hz;
+        let hz_response = ui.add(
+            egui::DragValue::new(&mut hz)
+                .speed(0.1)
+                .clamp_range(0.0001..=1_000_000.0)
+                .suffix(" Hz"),
+        );
+        if hz_response.changed() {
+            state.set_switch_rate_hz(hz);
+        }
+
+        let mut steps = state.config.delta_steps;
+        let steps_response = ui.add(
+            egui::DragValue::new(&mut steps)
+                .speed(1.0)
+                .range(1..=1_000_000)
+                .suffix(" steps"),
+        );
+        if steps_response.changed() {
+            state.set_delta_steps(steps);
+        }
+
+        ui.label(format!(
+            "Cycle period: {:.6} s ({} total steps)",
+            state.config.cycle_period_s(),
+            state.config.delta_steps * 4
+        ));
+    });
+
+    ui.separator();
+
+    ui.group(|ui| {
+        ui.label("Step Setpoints");
+        egui::Grid::new("switch-steps-grid")
+            .num_columns(3)
+            .spacing([8.0, 4.0])
+            .striped(true)
+            .show(ui, |ui| {
+                ui.heading("Step");
+                ui.heading("Mode");
+                ui.heading("Setpoint");
+                ui.end_row();
+
+                for step in 0..4u8 {
+                    let (pos, neg) = roles_for_step(step);
+                    ui.label(format!(
+                        "{}: {} → {}",
+                        step + 1,
+                        pos.display(),
+                        neg.display()
+                    ));
+
+                    let mut setpoint = state
+                        .config
+                        .step_setpoints
+                        .get(&step)
+                        .cloned()
+                        .unwrap_or_default();
+
+                    egui::ComboBox::from_id_source(format!("switch-step-mode-{step}"))
+                        .selected_text(match setpoint.mode {
+                            Mode::Current => "Current",
+                            Mode::Overpotential => "Overpotential",
+                        })
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut setpoint.mode, Mode::Current, "Current");
+                            ui.selectable_value(
+                                &mut setpoint.mode,
+                                Mode::Overpotential,
+                                "Overpotential",
+                            );
+                        })
+                        .response
+                        .on_hover_text(setpoint.mode.tooltip());
+
+                    let label = match setpoint.mode {
+                        Mode::Current => "Current (e/fs)",
+                        Mode::Overpotential => "Target ratio",
+                    };
+                    ui.horizontal(|ui| {
+                        ui.label(label);
+                        let mut value = setpoint.value;
+                        let response = ui.add(
+                            egui::DragValue::new(&mut value)
+                                .speed(0.1)
+                                .clamp_range(-10_000.0..=10_000.0),
+                        );
+                        if response.changed() {
+                            setpoint.value = value;
+                        }
+                    });
+
+                    state.edit_step(step, setpoint);
+                    ui.end_row();
+                }
+            });
+    });
+
+    ui.separator();
+
+    ui.horizontal(|ui| {
+        let run_enabled = state.validation_error.is_none();
+        if ui
+            .add_enabled(
+                run_enabled && state.run_state != RunState::Running,
+                egui::Button::new("▶ Run"),
+            )
+            .clicked()
+        {
+            state.start();
+        }
+        if ui
+            .add_enabled(
+                state.run_state == RunState::Running,
+                egui::Button::new("⏸ Pause"),
+            )
+            .clicked()
+        {
+            state.pause();
+        }
+        if ui.button("⏹ Stop").clicked() {
+            state.stop();
+        }
+        if ui.button("💾 Apply Config").clicked() {
+            state.send_update();
+        }
+    });
+
+    ui.separator();
+
+    ui.group(|ui| {
+        ui.label("Import / Export Configuration");
+        ui.horizontal(|ui| {
+            if ui.button("Export JSON").clicked() {
+                match serde_json::to_string_pretty(&state.config) {
+                    Ok(json) => {
+                        state.json_buffer = json;
+                        state.status_message = Some("Configuration exported".into());
+                        state.import_error = None;
+                    }
+                    Err(err) => {
+                        state.import_error = Some(format!("Failed to export: {err}"));
+                    }
+                }
+            }
+            if ui.button("Import JSON").clicked() {
+                match serde_json::from_str::<SwitchChargingConfig>(&state.json_buffer) {
+                    Ok(mut cfg) => {
+                        cfg.ensure_all_steps();
+                        state.config = cfg;
+                        state.config_dirty = true;
+                        state.update_validation();
+                        state.status_message = Some("Configuration imported".into());
+                        state.import_error = None;
+                    }
+                    Err(err) => {
+                        state.import_error = Some(format!("Import error: {err}"));
+                    }
+                }
+            }
+        });
+        if let Some(err) = &state.import_error {
+            ui.colored_label(egui::Color32::LIGHT_RED, err);
+        }
+        ui.add(
+            egui::TextEdit::multiline(&mut state.json_buffer)
+                .desired_rows(4)
+                .lock_focus(true)
+                .desired_width(f32::INFINITY),
+        );
+    });
+}
+
+pub fn default_sim_dt_s() -> f64 {
+    (crate::config::DEFAULT_DT_FS as f64) * 1e-15
+}
+
+#[allow(dead_code)]
+pub fn example_scheduler_loop(cfg: &SwitchChargingConfig, scheduler: &mut SwitchScheduler) {
+    scheduler.start(cfg);
+    let total_ticks = cfg.delta_steps.saturating_mul(4);
+    for _ in 0..total_ticks {
+        if let Some(((pos, neg), setpoint)) = scheduler.on_tick(cfg) {
+            let _ = (pos, neg, setpoint);
+            // In the real simulation this is where apply_foil_connection(pair, mode, value) would run.
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_valid_config() -> SwitchChargingConfig {
+        let mut cfg = SwitchChargingConfig::default();
+        cfg.role_to_foil.insert(Role::PosA, 1);
+        cfg.role_to_foil.insert(Role::NegA, 2);
+        cfg.role_to_foil.insert(Role::PosB, 3);
+        cfg.role_to_foil.insert(Role::NegB, 4);
+        cfg.delta_steps = 2;
+        cfg.recompute_from_steps();
+        cfg.ensure_all_steps();
+        cfg
+    }
+
+    #[test]
+    fn roles_follow_expected_sequence() {
+        let expected = vec![
+            (Role::PosA, Role::NegA),
+            (Role::PosB, Role::NegB),
+            (Role::PosB, Role::NegA),
+            (Role::PosA, Role::NegB),
+        ];
+        for i in 0..8u8 {
+            assert_eq!(roles_for_step(i), expected[(i % 4) as usize]);
+        }
+    }
+
+    #[test]
+    fn hz_to_steps_conversion_matches_dt() {
+        let mut cfg = make_valid_config();
+        cfg.sim_dt_s = 1e-4;
+        cfg.switch_rate_hz = 10.0;
+        cfg.recompute_from_hz();
+        assert_eq!(cfg.delta_steps, 1000);
+        cfg.delta_steps = 500;
+        cfg.recompute_from_steps();
+        assert!((cfg.switch_rate_hz - 20.0).abs() < 1e-6);
+
+        cfg.sim_dt_s = 5e-5;
+        cfg.switch_rate_hz = 50.0;
+        cfg.recompute_from_hz();
+        assert_eq!(cfg.delta_steps, 400);
+    }
+
+    #[test]
+    fn scheduler_cycles_in_order() {
+        let cfg = make_valid_config();
+        let mut scheduler = SwitchScheduler::default();
+        scheduler.start(&cfg);
+
+        let mut pairs = Vec::new();
+        for _ in 0..8 {
+            let ((a, b), _) = scheduler.on_tick(&cfg).expect("scheduler should emit");
+            pairs.push((a, b));
+        }
+        let expected = vec![
+            (1, 2),
+            (1, 2),
+            (3, 4),
+            (3, 4),
+            (3, 2),
+            (3, 2),
+            (1, 4),
+            (1, 4),
+        ];
+        assert_eq!(pairs, expected);
+    }
+
+    #[test]
+    fn validation_catches_errors() {
+        let mut cfg = make_valid_config();
+        assert!(cfg.validate().is_ok());
+
+        cfg.role_to_foil.remove(&Role::NegB);
+        assert!(cfg.validate().is_err());
+        cfg.role_to_foil.insert(Role::NegB, 3);
+        assert!(cfg.validate().is_err());
+        cfg.role_to_foil.insert(Role::NegB, 4);
+
+        cfg.switch_rate_hz = 0.0;
+        assert!(cfg.validate().is_err());
+        cfg.switch_rate_hz = 10.0;
+        cfg.delta_steps = 0;
+        assert!(cfg.validate().is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `switch_charging` module with UI state, scheduler, serde config, and tests
- surface a Switch Charging tab in the renderer and wire GUI interactions into the new module
- integrate switch-charging scheduling and control flow into the simulation loop and runtime state

## Testing
- `cargo check` *(fails: missing /workspace/quarkstrom/quarkstrom dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ccc98a20c883329f98fa13a0cda88e