### PR TITLE
Add LTO profile matrix and performance harness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,14 @@ path = "debug/detect_sawtooth_pattern.rs"
 name = "toml_density_analysis"
 path = "debug/toml_density_analysis.rs"
 
+[[bin]]
+name = "perf_harness"
+path = "scripts/perf_harness.rs"
+
+[[bin]]
+name = "runtime_probe"
+path = "scripts/runtime_probe.rs"
+
 [dependencies]
 quarkstrom = { path = "../quarkstrom/quarkstrom" }
 
@@ -102,13 +110,29 @@ screenshots = "0.7"
 # No build dependencies needed currently
 
 [profile.dev]
-# Development profile optimizations for faster builds with dependencies
+# Development profile tuned for fast iteration
 incremental = true
+lto = false
+codegen-units = 16
+debug = 1
 
 [profile.release]
-# Release profile with parallel compilation
-lto = thin  # Thin LTO - faster compile than full LTO, still good optimization
-codegen-units = 16  # Use parallel codegen units for faster compilation
+# Baseline release profile with maximum optimization
+lto = "fat"
+codegen-units = 1
+
+[profile.release-thin]
+# Release profile matching the previous thin-LTO settings
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
+[profile.release-fast]
+# High-throughput profile for near-release performance with faster builds
+inherits = "release"
+lto = false
+codegen-units = 16
+incremental = true
 
 [features]
 profiling = []

--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ guidelines.
    cargo run --release
    ```
 
+### Build profiles
+
+ParticleSim now ships with explicit Cargo profiles tuned for the LTO
+investigation:
+
+| Profile | LTO | Codegen Units | Notes |
+| --- | --- | --- | --- |
+| `dev` | `false` | 16 | Fast incremental builds with minimal debug info (debug level 1). |
+| `release` | `"fat"` | 1 | Baseline configuration for maximum runtime performance. |
+| `release-thin` | `"thin"` | 16 | Matches the previous default thin-LTO setup for comparison. |
+| `release-fast` | `false` | 16 | High-throughput builds for profiling without LTO. |
+
+Use these profiles with `cargo build --profile <name>` to switch between
+configurations without editing `Cargo.toml`.
+
 ---
 
 ## Controls
@@ -156,6 +171,13 @@ The simulation includes a comprehensive plotting system for real-time data analy
 - **Configurable Physics**: Modify parameters in real-time through the GUI
 - **Comprehensive Testing**: Run the test suite with `cargo test`
 - **Performance Profiling**: Enable with `cargo run --features profiling`
+
+### Performance measurement harness
+
+Run `cargo run --bin perf_harness` to collect build timings and runtime
+benchmarks for the full LTO/codegen-unit matrix. The harness generates CSV
+artifacts under `docs/perf/` summarising wall-clock build times, binary sizes,
+and simulation throughput metrics from the `runtime_probe` benchmark.
 
 ---
 

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,49 @@
+# Performance Harness
+
+The performance harness automates the build and runtime measurements required for
+profiling Link Time Optimization (LTO) and codegen-unit combinations. It sweeps
+the `{lto ∈ [false, thin, fat]} × {codegen-units ∈ [1, 4, 8, 16]}` matrix and
+captures comparable metrics for each configuration.
+
+## Running the harness
+
+```sh
+cargo run --bin perf_harness
+```
+
+The harness performs the following steps for every LTO/codegen-unit pair:
+
+1. Builds the `particle_sim` release binary with `cargo build --timings=json`
+   while forcing the desired `-C lto` and `-C codegen-units` flags via
+   `RUSTFLAGS`. Each build uses an isolated `target/perf/lto-<lto>-cgu-<N>`
+   directory to guarantee clean measurements.
+2. Records build wall-clock time, parses the `cargo-timings` JSON report, and
+   captures the resulting binary size.
+3. Compiles the lightweight `runtime_probe` benchmark binary with the same
+   compiler settings and executes it to measure simulation throughput.
+
+> **Note:** Running the full matrix performs 12 clean release builds. The first
+> invocation may take several minutes depending on host hardware. Subsequent
+> runs benefit from the cached source downloads and linked dependencies but
+> still rebuild the crate for each configuration.
+
+## Output artifacts
+
+The harness writes two CSV files under `docs/perf/`:
+
+- `lto-build-matrix.csv` – build wall-clock time, Cargo timing totals, and final
+  binary size for each configuration.
+- `runtime-benchmarks.csv` – runtime metrics from the `runtime_probe` benchmark
+  including total wall-clock time, mean step duration, and slowdown factor.
+
+Each run overwrites the CSV files, making it easy to commit refreshed data
+alongside code changes. The CSV headers are stable, so they can be imported into
+spreadsheets or plotting tools directly.
+
+## Related tooling
+
+- `scripts/runtime_probe.rs` – small benchmark binary that steps a canonical
+  simulation workload and emits JSON with timing data.
+- `Cargo.toml` profiles – use `cargo build --profile release-thin` or `cargo
+  build --profile release-fast` for ad hoc comparisons without running the full
+  harness.

--- a/docs/perf/lto-build-matrix.csv
+++ b/docs/perf/lto-build-matrix.csv
@@ -1,0 +1,1 @@
+lto,codegen_units,build_seconds,timing_wall_seconds,binary_size_bytes

--- a/docs/perf/runtime-benchmarks.csv
+++ b/docs/perf/runtime-benchmarks.csv
@@ -1,0 +1,1 @@
+lto,codegen_units,steps,bodies,sample_window,total_step_micros,avg_step_micros,early_avg_micros,late_avg_micros,slowdown_factor,wall_time_seconds

--- a/scripts/perf_harness.rs
+++ b/scripts/perf_harness.rs
@@ -1,0 +1,307 @@
+use serde::Deserialize;
+use serde_json::Value;
+use std::error::Error;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+const LTO_OPTIONS: &[(&str, &str)] = &[("false", "off"), ("thin", "thin"), ("fat", "fat")];
+const CODEGEN_UNITS: &[u32] = &[1, 4, 8, 16];
+
+#[derive(Debug)]
+struct BuildMeasurement {
+    lto: String,
+    codegen_units: u32,
+    build_seconds: f64,
+    timing_wall_seconds: Option<f64>,
+    binary_size_bytes: u64,
+}
+
+#[derive(Debug)]
+struct RuntimeMeasurement {
+    lto: String,
+    codegen_units: u32,
+    wall_time_seconds: f64,
+    steps: usize,
+    bodies: usize,
+    sample_window: usize,
+    total_step_micros: u128,
+    avg_step_micros: f64,
+    early_avg_micros: f64,
+    late_avg_micros: f64,
+    slowdown_factor: f64,
+}
+
+#[derive(Deserialize)]
+struct RuntimeReport {
+    steps: usize,
+    bodies: usize,
+    sample_window: usize,
+    total_step_micros: u128,
+    wall_time_micros: u128,
+    avg_step_micros: f64,
+    early_avg_micros: f64,
+    late_avg_micros: f64,
+    slowdown_factor: f64,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all("docs/perf")?;
+    fs::create_dir_all("target/perf")?;
+
+    let mut build_metrics = Vec::new();
+    let mut runtime_metrics = Vec::new();
+
+    for &(label, rustc_lto) in LTO_OPTIONS {
+        for &codegen_units in CODEGEN_UNITS {
+            println!(
+                "\n=== Measuring build: lto={} | codegen-units={} ===",
+                label, codegen_units
+            );
+            let target_dir =
+                PathBuf::from("target/perf").join(format!("lto-{}-cgu-{}", label, codegen_units));
+            if target_dir.exists() {
+                fs::remove_dir_all(&target_dir)?;
+            }
+
+            let rustflags = format!("-C lto={} -C codegen-units={}", rustc_lto, codegen_units);
+            let build = measure_build(&target_dir, label, &rustflags, codegen_units)?;
+            build_metrics.push(build);
+
+            println!(
+                "--- Capturing runtime: lto={} | codegen-units={} ---",
+                label, codegen_units
+            );
+            let runtime = measure_runtime(&target_dir, label, &rustflags, codegen_units)?;
+            runtime_metrics.push(runtime);
+        }
+    }
+
+    write_build_csv(&build_metrics)?;
+    write_runtime_csv(&runtime_metrics)?;
+
+    println!("\nBuild metrics written to docs/perf/lto-build-matrix.csv");
+    println!("Runtime metrics written to docs/perf/runtime-benchmarks.csv");
+
+    Ok(())
+}
+
+fn measure_build(
+    target_dir: &Path,
+    lto_label: &str,
+    rustflags: &str,
+    codegen_units: u32,
+) -> Result<BuildMeasurement, Box<dyn Error>> {
+    if let Some(parent) = target_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--release")
+        .arg("--bin")
+        .arg("particle_sim")
+        .arg("--target-dir")
+        .arg(target_dir)
+        .arg("--timings=json");
+    cmd.env("RUSTFLAGS", rustflags);
+
+    let start = Instant::now();
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(format!(
+            "cargo build failed for lto={} codegen-units={}",
+            lto_label, codegen_units
+        )
+        .into());
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+
+    let binary_path = target_dir.join("release").join(binary_name("particle_sim"));
+    let binary_size = fs::metadata(&binary_path)?.len();
+
+    let timing_wall_seconds = read_latest_timing(target_dir)?;
+
+    Ok(BuildMeasurement {
+        lto: lto_label.to_string(),
+        codegen_units,
+        build_seconds: elapsed,
+        timing_wall_seconds,
+        binary_size_bytes: binary_size,
+    })
+}
+
+fn measure_runtime(
+    target_dir: &Path,
+    lto_label: &str,
+    rustflags: &str,
+    codegen_units: u32,
+) -> Result<RuntimeMeasurement, Box<dyn Error>> {
+    if let Some(parent) = target_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut build_cmd = Command::new("cargo");
+    build_cmd
+        .arg("build")
+        .arg("--release")
+        .arg("--bin")
+        .arg("runtime_probe")
+        .arg("--target-dir")
+        .arg(target_dir);
+    build_cmd.env("RUSTFLAGS", rustflags);
+
+    let status = build_cmd.status()?;
+    if !status.success() {
+        return Err(format!(
+            "cargo build (runtime probe) failed for lto={} codegen-units={}",
+            lto_label, codegen_units
+        )
+        .into());
+    }
+
+    let probe_path = target_dir
+        .join("release")
+        .join(binary_name("runtime_probe"));
+
+    let runtime_start = Instant::now();
+    let output = Command::new(&probe_path)
+        .arg("--steps")
+        .arg("200")
+        .arg("--bodies")
+        .arg("300")
+        .arg("--window")
+        .arg("20")
+        .output()?;
+    let wall_time_seconds = runtime_start.elapsed().as_secs_f64();
+
+    if !output.status.success() {
+        return Err(format!(
+            "runtime probe failed for lto={} codegen-units={}",
+            lto_label, codegen_units
+        )
+        .into());
+    }
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let report: RuntimeReport = serde_json::from_str(stdout.trim())?;
+
+    Ok(RuntimeMeasurement {
+        lto: lto_label.to_string(),
+        codegen_units,
+        wall_time_seconds,
+        steps: report.steps,
+        bodies: report.bodies,
+        sample_window: report.sample_window,
+        total_step_micros: report.total_step_micros,
+        avg_step_micros: report.avg_step_micros,
+        early_avg_micros: report.early_avg_micros,
+        late_avg_micros: report.late_avg_micros,
+        slowdown_factor: report.slowdown_factor,
+    })
+}
+
+fn write_build_csv(records: &[BuildMeasurement]) -> Result<(), Box<dyn Error>> {
+    let mut file = File::create("docs/perf/lto-build-matrix.csv")?;
+    writeln!(
+        file,
+        "lto,codegen_units,build_seconds,timing_wall_seconds,binary_size_bytes"
+    )?;
+
+    for record in records {
+        let timing = record.timing_wall_seconds.unwrap_or(record.build_seconds);
+        writeln!(
+            file,
+            "{},{},{:.3},{:.3},{}",
+            record.lto,
+            record.codegen_units,
+            record.build_seconds,
+            timing,
+            record.binary_size_bytes
+        )?;
+    }
+
+    Ok(())
+}
+
+fn write_runtime_csv(records: &[RuntimeMeasurement]) -> Result<(), Box<dyn Error>> {
+    let mut file = File::create("docs/perf/runtime-benchmarks.csv")?;
+    writeln!(
+        file,
+        "lto,codegen_units,steps,bodies,sample_window,total_step_micros,avg_step_micros,early_avg_micros,late_avg_micros,slowdown_factor,wall_time_seconds"
+    )?;
+
+    for record in records {
+        writeln!(
+            file,
+            "{},{},{},{},{},{},{:.3},{:.3},{:.3},{:.4},{:.3}",
+            record.lto,
+            record.codegen_units,
+            record.steps,
+            record.bodies,
+            record.sample_window,
+            record.total_step_micros,
+            record.avg_step_micros,
+            record.early_avg_micros,
+            record.late_avg_micros,
+            record.slowdown_factor,
+            record.wall_time_seconds
+        )?;
+    }
+
+    Ok(())
+}
+
+fn read_latest_timing(target_dir: &Path) -> Result<Option<f64>, Box<dyn Error>> {
+    let timing_dir = target_dir.join("cargo-timings");
+    if !timing_dir.exists() {
+        return Ok(None);
+    }
+
+    let mut latest: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in fs::read_dir(&timing_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+
+        let metadata = entry.metadata()?;
+        let modified = metadata.modified()?;
+        match &mut latest {
+            Some((stored_time, stored_path)) => {
+                if modified > *stored_time {
+                    *stored_time = modified;
+                    *stored_path = path;
+                }
+            }
+            None => {
+                latest = Some((modified, path));
+            }
+        }
+    }
+
+    let (_, path) = match latest {
+        Some(pair) => pair,
+        None => return Ok(None),
+    };
+
+    let data = fs::read_to_string(path)?;
+    let json: Value = serde_json::from_str(&data)?;
+    let wall = json
+        .get("wall_time")
+        .and_then(Value::as_f64)
+        .or_else(|| json.get("wall-time").and_then(Value::as_f64));
+
+    Ok(wall)
+}
+
+fn binary_name(name: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{}.exe", name)
+    } else {
+        name.to_string()
+    }
+}

--- a/scripts/runtime_probe.rs
+++ b/scripts/runtime_probe.rs
@@ -1,0 +1,113 @@
+use particle_sim::{body, simulation};
+use serde::Serialize;
+use std::{env, time::Instant};
+use ultraviolet::Vec2;
+
+#[derive(Serialize)]
+struct RuntimeReport {
+    steps: usize,
+    bodies: usize,
+    sample_window: usize,
+    total_step_micros: u128,
+    wall_time_micros: u128,
+    avg_step_micros: f64,
+    early_avg_micros: f64,
+    late_avg_micros: f64,
+    slowdown_factor: f64,
+}
+
+fn parse_arg(args: &[String], flag: &str, default: usize) -> usize {
+    for window in args.windows(2) {
+        if window[0] == flag {
+            return window[1].parse().unwrap_or(default);
+        }
+    }
+
+    let prefix = format!("{}=", flag);
+    for arg in args {
+        if let Some(value) = arg.strip_prefix(&prefix) {
+            return value.parse().unwrap_or(default);
+        }
+    }
+
+    default
+}
+
+fn build_simulation(bodies: usize) -> simulation::Simulation {
+    let mut sim = simulation::Simulation::new();
+
+    for i in 0..bodies {
+        let angle = i as f32 * 0.1;
+        let radius = (i as f32 * 0.05) % 15.0;
+        let x = radius * angle.cos();
+        let y = radius * angle.sin();
+
+        let body = body::Body::new(
+            Vec2::new(x, y),
+            Vec2::new(0.1, 0.1),
+            1.0,
+            1.0,
+            1.0,
+            body::Species::LithiumIon,
+        );
+        sim.bodies.push(body);
+    }
+
+    sim
+}
+
+fn average(slice: &[u128]) -> f64 {
+    if slice.is_empty() {
+        0.0
+    } else {
+        slice.iter().copied().sum::<u128>() as f64 / slice.len() as f64
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let steps = parse_arg(&args, "--steps", 200);
+    let bodies = parse_arg(&args, "--bodies", 300);
+    let sample_window = parse_arg(&args, "--window", 20).max(1);
+
+    let mut sim = build_simulation(bodies);
+    let mut durations = Vec::with_capacity(steps);
+
+    let wall_start = Instant::now();
+    for _ in 0..steps {
+        let step_start = Instant::now();
+        sim.step();
+        durations.push(step_start.elapsed().as_micros());
+    }
+    let wall_time = wall_start.elapsed().as_micros();
+
+    let total_step_micros: u128 = durations.iter().copied().sum();
+    let window = sample_window.min(steps).max(1);
+
+    let early_slice = &durations[..window];
+    let late_slice = &durations[steps - window..];
+
+    let early_avg = average(early_slice);
+    let late_avg = average(late_slice);
+
+    let report = RuntimeReport {
+        steps,
+        bodies,
+        sample_window: window,
+        total_step_micros,
+        wall_time_micros: wall_time,
+        avg_step_micros: total_step_micros as f64 / steps as f64,
+        early_avg_micros: early_avg,
+        late_avg_micros: late_avg,
+        slowdown_factor: if early_avg > 0.0 {
+            late_avg / early_avg
+        } else {
+            0.0
+        },
+    };
+
+    println!(
+        "{}",
+        serde_json::to_string(&report).expect("failed to serialize runtime report")
+    );
+}


### PR DESCRIPTION
## Summary
- restore the release profile to the documented full-LTO baseline, add thin/fast variants, and tune the dev profile for quick builds
- add `perf_harness` and `runtime_probe` binaries plus docs to sweep LTO/codegen-unit matrices and capture build/runtime metrics

## Testing
- cargo check *(fails: crates.io index blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d1bad04e6c83329e21cee941418db2