### PR TITLE
Add measurement tool to renderer

### DIFF
--- a/src/renderer/gui/measurement_tab.rs
+++ b/src/renderer/gui/measurement_tab.rs
@@ -1,0 +1,96 @@
+use super::*;
+use egui::{Grid, RichText};
+
+impl super::super::Renderer {
+    pub fn show_measurement_tab(&mut self, ui: &mut egui::Ui) {
+        ui.heading("📏 Measurement Tool");
+        ui.label("Select a starting point and move the cursor in the simulation view to see live distances.");
+
+        ui.horizontal(|ui| {
+            if ui.button("🎯 Select Start Point").clicked() {
+                self.measurement_selecting_start = true;
+            }
+
+            let copy_enabled = !self.measurement_history.is_empty();
+            let copy_button =
+                ui.add_enabled(copy_enabled, egui::Button::new("📋 Copy History (.csv)"));
+            if copy_button.clicked() {
+                let mut csv = String::from("step,time_fs,distance\n");
+                for record in &self.measurement_history {
+                    csv.push_str(&format!(
+                        "{},{:.6},{:.6}\n",
+                        record.step, record.time_fs, record.distance
+                    ));
+                }
+                ui.output_mut(|o| o.copied_text = csv);
+                ui.label(RichText::new("History copied to clipboard").italics());
+            }
+        });
+
+        if self.measurement_selecting_start {
+            ui.label(
+                RichText::new("Click in the simulation view to set the starting point.").italics(),
+            );
+        }
+
+        ui.separator();
+
+        match self.measurement_start {
+            Some(start) => {
+                ui.label(format!("Starting point: ({:.2}, {:.2})", start.x, start.y));
+            }
+            None => {
+                ui.label("No starting point selected yet.");
+            }
+        }
+
+        match self.current_measurement_distance() {
+            Some(distance) => {
+                ui.label(format!("Current distance: {:.3}", distance));
+            }
+            None => {
+                if self.measurement_start.is_some() {
+                    ui.label("Current distance: move the mouse over the simulation view.");
+                } else {
+                    ui.label("Current distance: select a starting point to begin measuring.");
+                }
+            }
+        }
+
+        if let Some(cursor) = self.measurement_cursor {
+            ui.label(format!(
+                "Current cursor: ({:.2}, {:.2})",
+                cursor.x, cursor.y
+            ));
+        }
+
+        ui.small("Left-click in the simulation view to record a measurement. Right-click or switch tabs to exit measurement mode.");
+
+        ui.separator();
+        ui.label("📚 Measurement History");
+
+        if self.measurement_history.is_empty() {
+            ui.label("No measurements recorded yet.");
+        } else {
+            egui::ScrollArea::vertical()
+                .max_height(200.0)
+                .show(ui, |ui| {
+                    Grid::new("measurement_history_grid")
+                        .striped(true)
+                        .show(ui, |ui| {
+                            ui.label(RichText::new("Step").strong());
+                            ui.label(RichText::new("Time (fs)").strong());
+                            ui.label(RichText::new("Distance").strong());
+                            ui.end_row();
+
+                            for record in self.measurement_history.iter().rev() {
+                                ui.label(format!("{}", record.step));
+                                ui.label(format!("{:.3}", record.time_fs));
+                                ui.label(format!("{:.3}", record.distance));
+                                ui.end_row();
+                            }
+                        });
+                });
+        }
+    }
+}

--- a/src/renderer/gui/mod.rs
+++ b/src/renderer/gui/mod.rs
@@ -13,8 +13,9 @@ pub mod analysis_tab;
 pub mod debug_tab;
 pub mod diagnostics_tab;
 pub mod foils_tab;
-pub mod pid_controller;
+pub mod measurement_tab;
 pub mod physics_tab;
+pub mod pid_controller;
 pub mod scenario_tab;
 pub mod screen_capture_tab;
 pub mod simulation_tab;
@@ -109,6 +110,11 @@ impl super::Renderer {
                         );
                         ui.selectable_value(
                             &mut self.current_tab,
+                            super::GuiTab::Measurement,
+                            "📏 Measurement",
+                        );
+                        ui.selectable_value(
+                            &mut self.current_tab,
                             super::GuiTab::SwitchCharging,
                             "🔁 Switch Charging",
                         );
@@ -121,6 +127,10 @@ impl super::Renderer {
                 });
 
                 ui.separator();
+
+                if self.current_tab != super::GuiTab::Measurement {
+                    self.last_non_measurement_tab = self.current_tab;
+                }
 
                 self.switch_ui_state
                     .sync_sim_dt(*crate::renderer::state::TIMESTEP.lock());
@@ -142,6 +152,7 @@ impl super::Renderer {
                         super::GuiTab::SwitchCharging => {
                             switch_charging::ui_switch_charging(ui, &mut self.switch_ui_state)
                         }
+                        super::GuiTab::Measurement => self.show_measurement_tab(ui),
                         super::GuiTab::Analysis => self.show_analysis_tab(ui),
                         super::GuiTab::Debug => self.show_debug_tab(ui),
                         super::GuiTab::Diagnostics => self.show_diagnostics_tab(ui),


### PR DESCRIPTION
## Summary
- add a Measurement tab that shows the current cursor distance, lets the user pick a start point, and exports measurements as CSV
- track measurement state/history in the renderer and input handling so left/right clicks enter or log readings appropriately
- render measurement markers with dashed guide lines when the measurement tab is active

## Testing
- `cargo check` *(fails: missing `quarkstrom` dependency and crates.io access in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d3deb5b39c8332b29cad60f210effc