### PR TITLE
Persist and compress playback history in saves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,7 @@ dependencies = [
  "chrono",
  "crossbeam",
  "fastrand",
+ "flate2",
  "image",
  "once_cell",
  "palette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ serde = { version = "1.0", features = ["derive"] }
 
 serde_json = "1.0"
 toml = "0.8"
+flate2 = { version = "1.1", features = ["gzip"] }
 
 # Screen capture dependencies
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/src/app/command_loop.rs
+++ b/src/app/command_loop.rs
@@ -134,8 +134,8 @@ pub fn handle_command(cmd: SimCommand, simulation: &mut Simulation) {
             }
         }
         SimCommand::LoadState { path } => match load_state(path) {
-            Ok(state) => {
-                simulation.load_state(state);
+            Ok(scenario) => {
+                simulation.load_state(scenario);
                 PAUSED.store(true, Ordering::Relaxed);
                 state_changed = true;
             }
@@ -412,7 +412,7 @@ pub fn handle_command(cmd: SimCommand, simulation: &mut Simulation) {
             simulation
                 .cell_list
                 .update_domain_size(half_width, half_height);
-            
+
             // Update shared state so GUI stays in sync
             *crate::renderer::state::DOMAIN_WIDTH.lock() = width;
             *crate::renderer::state::DOMAIN_HEIGHT.lock() = height;

--- a/src/commands/state.rs
+++ b/src/commands/state.rs
@@ -29,8 +29,8 @@ pub fn handle_save_state(simulation: &Simulation, path: String) {
 /// Load the simulation state from disk.
 pub fn handle_load_state(simulation: &mut Simulation, path: String) {
     match load_state(path) {
-        Ok(state) => {
-            simulation.load_state(state);
+        Ok(scenario) => {
+            simulation.load_state(scenario);
             PAUSED.store(true, std::sync::atomic::Ordering::Relaxed);
         }
         Err(e) => eprintln!("Failed to load state: {}", e),


### PR DESCRIPTION
## Summary
- add a `SavedScenario` wrapper so saves include current state, history frames, and cursor metadata
- update serialization to write/read the wrapper while falling back to legacy single-state files
- rebuild the simulation history buffer and cursor from loaded saves and update command handlers to use the new API
- compress saved scenarios with gzip when writing and transparently decompress them when loading to shrink disk usage

## Testing
- cargo check *(fails: unable to access path dependency `quarkstrom` and crates.io index due to CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d3dfa57a408332be03c135b49dccb9